### PR TITLE
Inline the onSuccess() and onFailure() functions

### DIFF
--- a/src/main/kotlin/com/github/michaelbull/result/On.kt
+++ b/src/main/kotlin/com/github/michaelbull/result/On.kt
@@ -4,10 +4,10 @@ package com.github.michaelbull.result
  * Calls a [callback] if the [Result] is [Ok].
  * @param callback The function to call.
  */
-fun <V, E> Result<V, E>.onSuccess(callback: (V) -> Unit) = mapBoth(callback, {})
+inline fun <V, E> Result<V, E>.onSuccess(callback: (V) -> Unit) = mapBoth(callback, {})
 
 /**
  * Calls a [callback] if the [Result] is [Err].
  * @param callback The function to call.
  */
-fun <V, E> Result<V, E>.onFailure(callback: (E) -> Unit) = mapBoth({}, callback)
+inline fun <V, E> Result<V, E>.onFailure(callback: (E) -> Unit) = mapBoth({}, callback)


### PR DESCRIPTION
It looks like all the other functions that receive callbacks are already inlined. These two were missed, and without being inlined the callbacks can't, for example, suspend the current coroutine.