### PR TITLE
Add monad comprehensions via binding block with bind extension function

### DIFF
--- a/src/main/kotlin/com/github/michaelbull/result/bind/BindFailure.kt
+++ b/src/main/kotlin/com/github/michaelbull/result/bind/BindFailure.kt
@@ -1,0 +1,9 @@
+package com.github.michaelbull.result.bind
+
+sealed class NoStackTraceException : Exception() {
+    override fun fillInStackTrace(): Throwable {
+        return this
+    }
+
+    object BindFailure : NoStackTraceException()
+}

--- a/src/main/kotlin/com/github/michaelbull/result/bind/BindFailure.kt
+++ b/src/main/kotlin/com/github/michaelbull/result/bind/BindFailure.kt
@@ -1,9 +1,8 @@
 package com.github.michaelbull.result.bind
 
-sealed class NoStackTraceException : Exception() {
+internal object BindFailure : Exception() {
+    // no stacktrace needed
     override fun fillInStackTrace(): Throwable {
         return this
     }
-
-    object BindFailure : NoStackTraceException()
 }

--- a/src/main/kotlin/com/github/michaelbull/result/bind/ResultBinding.kt
+++ b/src/main/kotlin/com/github/michaelbull/result/bind/ResultBinding.kt
@@ -1,0 +1,7 @@
+package com.github.michaelbull.result.bind
+
+import com.github.michaelbull.result.Result
+
+interface ResultBinding<E> {
+    fun <V> Result<V, E>.bind(): V
+}

--- a/src/main/kotlin/com/github/michaelbull/result/bind/ResultBindingImpl.kt
+++ b/src/main/kotlin/com/github/michaelbull/result/bind/ResultBindingImpl.kt
@@ -4,7 +4,6 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
-import com.github.michaelbull.result.bind.NoStackTraceException.BindFailure
 
 /**
  * Calls the specified function [block] with [ResultBindingImpl] as its receiver and returns a [Result] of either [Ok] with value [V] or [Err] with error [E].
@@ -38,9 +37,8 @@ internal class ResultBindingImpl<E> : ResultBinding<E> {
     internal companion object {
         inline fun <V, E> with(crossinline block: ResultBindingImpl<E>.() -> V): Result<V, E> {
             val context = ResultBindingImpl<E>()
-            val wrapResult: ResultBindingImpl<E>.() -> Result<V, E> = { Ok(block()) }
             return try {
-                with(context, wrapResult)
+                with(context) { Ok(block()) }
             } catch (e: BindFailure) {
                 context.error
             }

--- a/src/main/kotlin/com/github/michaelbull/result/bind/ResultBindingImpl.kt
+++ b/src/main/kotlin/com/github/michaelbull/result/bind/ResultBindingImpl.kt
@@ -1,0 +1,49 @@
+package com.github.michaelbull.result.bind
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getOrElse
+import com.github.michaelbull.result.bind.NoStackTraceException.BindFailure
+
+/**
+ * Calls the specified function [block] with [ResultBindingImpl] as its receiver and returns a [Result] of either [Ok] with value [V] or [Err] with error [E].
+ *
+ * [ResultBinding.bind] extension function is made available to any [Result] object inside this [block].
+ * [ResultBinding.bind] will attempt to unwrap the [Result] to return its [Ok] value locally.
+ * If the result is a [Err], then the [binding] block terminates with that [ResultBinding.bind] and returns a [Result] containing the error of the failed binding.
+ *
+ * This allows for easy unwrapping of result type objects along a happy path.
+ * for examples, see tests
+ * @sample com.github.michaelbull.result.bind.ResultBindingTest
+ *
+ */
+inline fun <V, E> binding(crossinline block: ResultBinding<E>.() -> V): Result<V, E> {
+    return ResultBindingImpl.with(block)
+}
+
+@PublishedApi
+internal class ResultBindingImpl<E> : ResultBinding<E> {
+
+    lateinit var error: Err<E>
+
+    override fun <V> Result<V, E>.bind(): V {
+        return this.getOrElse {
+            error = Err(it)
+            throw BindFailure
+        }
+    }
+
+    @PublishedApi
+    internal companion object {
+        inline fun <V, E> with(crossinline block: ResultBindingImpl<E>.() -> V): Result<V, E> {
+            val context = ResultBindingImpl<E>()
+            val wrapResult: ResultBindingImpl<E>.() -> Result<V, E> = { Ok(block()) }
+            return try {
+                with(context, wrapResult)
+            } catch (e: BindFailure) {
+                context.error
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/github/michaelbull/result/bind/ResultBindingTest.kt
+++ b/src/test/kotlin/com/github/michaelbull/result/bind/ResultBindingTest.kt
@@ -1,0 +1,70 @@
+package com.github.michaelbull.result.bind
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ResultBindingTest {
+
+    @Test
+    fun `GIVEN a ResultBinding which contains all ok binds THEN return ok Result`() {
+        val result = binding<Int, Exception> {
+            val x = okIntResult().bind()
+            val y = okIntResult().bind()
+            x + y
+        }
+
+        assertTrue(result is Ok)
+        assertEquals(2, result.value)
+    }
+
+    @Test
+    fun `GIVEN a ResultBinding which contains all ok binds that are not of the same type WHEN the returning type matches the ResultBinding type THEN return ok Result`() {
+        val result = binding<Int, Exception> {
+            val x = okStringResult().bind()
+            val y = Ok(x.toInt() + 2).bind()
+            y
+        }
+
+        assertTrue(result is Ok)
+        assertEquals(3, result.value)
+    }
+
+    @Test
+    fun `GIVEN a ResultBinding which contains an err bind THEN return that bind's error in Result`() {
+        val someException = Exception()
+        val result = binding<Int, Exception> {
+            val x = okIntResult().bind()
+            val e = errIntResult(someException).bind()
+            val y = okIntResult().bind()
+            x + y
+        }
+
+        assertTrue(result is Err)
+        assertEquals(someException, result.error)
+    }
+
+    @Test
+    fun `GIVEN a ResultBinding which contains a function with an ok type not matching the ResultBinding WHEN it fails to bind THEN return that bind's error reason in Result`() {
+        val someException = Exception()
+        val result = binding<Int, Exception> {
+            val x = okIntResult().bind()
+            val e = errStringResult(someException).bind()
+            val y = okIntResult().bind()
+            x + y
+        }
+
+        assertTrue(result is Err)
+        assertEquals(someException, result.error)
+    }
+
+    companion object {
+        fun okIntResult(): Result<Int, Exception> = Ok(1)
+        fun okStringResult(): Result<String, Exception> = Ok("1")
+        fun errIntResult(exception: Exception): Result<Int, Exception> = Err(exception)
+        fun errStringResult(exception: Exception): Result<String, Exception> = Err(exception)
+    }
+}


### PR DESCRIPTION
Hello!

Thought I would open a pull request to add monad comprehension like syntax for this result type.
Full disclosure: before i knew about this repo I had looked to adding this feature for result4k: https://github.com/npryce/result4k/pull/3
Wasn't getting a response there so I've moved on 😅 that's when I started looking around and found this very cool repo!

For that pr I did quite a bit of micro benchmarking with jmh. The main reason for not moving forward with arrow's either type for me is how poor performing it is. The apis are also very unstable (still not at a 1.0 release). So it was important for me to choose another lib that was performant.

With my (possibly contrived) test I have benchmarked and compared flatmapping versus using my proposed bind syntax for this repo. It came out a little slower: 

Lib | Success Flow | Failure Flow
------------ | ---------------- | -------------
ResultBinding | 187250 ops/ms | 178704 ops/ms
flatmap | 280932 ops/ms | 258156 ops/ms 

One thing to point out is that comparing this library to Result4k, the ops/ms is significantly slower in this repo for flatmapping (i get around 250,000 - 280,000 ops/ms in this repo, compared to almost 450,000 ops/ms in result4k on my machine). I suspect its related to the use of contracts and more object creation in this repo. Regardless, its still pretty fast! just thought its interesting.

Anyway, hope your open to the proposal and keeping well in these strange times!

