### PR TITLE
andThenRun and andThenMap

### DIFF
--- a/example/src/main/kotlin/com/github/michaelbull/result/example/service/CustomerService.kt
+++ b/example/src/main/kotlin/com/github/michaelbull/result/example/service/CustomerService.kt
@@ -1,7 +1,6 @@
 package com.github.michaelbull.result.example.service
 
-import com.github.michaelbull.result.Result
-import com.github.michaelbull.result.andThen
+import com.github.michaelbull.result.*
 import com.github.michaelbull.result.example.model.domain.Customer
 import com.github.michaelbull.result.example.model.domain.CustomerCreated
 import com.github.michaelbull.result.example.model.domain.CustomerId
@@ -11,12 +10,6 @@ import com.github.michaelbull.result.example.model.domain.DatabaseTimeout
 import com.github.michaelbull.result.example.model.domain.DomainMessage
 import com.github.michaelbull.result.example.model.domain.EmailAddressChanged
 import com.github.michaelbull.result.example.model.entity.CustomerEntity
-import com.github.michaelbull.result.map
-import com.github.michaelbull.result.mapAll
-import com.github.michaelbull.result.mapBoth
-import com.github.michaelbull.result.mapError
-import com.github.michaelbull.result.runCatching
-import com.github.michaelbull.result.toResultOr
 import java.sql.SQLTimeoutException
 
 object CustomerService {
@@ -29,7 +22,7 @@ object CustomerService {
     }
 
     fun getById(id: CustomerId): Result<Customer, DomainMessage> {
-        return getAll().andThen { customers -> customers.findCustomer(id) }
+        return getAll().andThenRun{ findCustomer(id) }
     }
 
     fun upsert(customer: Customer): Result<DomainMessage?, DomainMessage> {

--- a/src/main/kotlin/com/github/michaelbull/result/And.kt
+++ b/src/main/kotlin/com/github/michaelbull/result/And.kt
@@ -41,3 +41,26 @@ inline infix fun <V, E, U> Result<V, E>.andThen(transform: (V) -> Result<U, E>):
         is Err -> this
     }
 }
+
+/**
+ * Maps this [Result<V, E>][Result] to [Result<U, E>][Result] by either applying the [transform]
+ * function if this [Result] is [Ok], or returning this [Err].
+ * [transform] is a lambda with receiver, so that its parameter is accessible through [this]
+ *
+ * - Elm: [Result.andThen](http://package.elm-lang.org/packages/elm-lang/core/latest/Result#andThen)
+ * - Rust: [Result.and_then](https://doc.rust-lang.org/std/result/enum.Result.html#method.and_then)
+ */
+inline infix fun <V, E, U> Result<V, E>.andThenRun(transform: V.() -> Result<U, E>): Result<U, E> =
+    andThen(transform)
+
+/**
+ * Maps this [Result<V, E>][Result] to [Result<U, E>][Result] by either applying the [transform]
+ * function to the [value][Ok.value] if this [Result] is [Ok], or returning this [Err].
+ * [transform] is a lambda with receiver, so that its parameter is accessible through [this]
+ *
+ * - Elm: [Result.map](http://package.elm-lang.org/packages/elm-lang/core/latest/Result#map)
+ * - Haskell: [Data.Bifunctor.first](https://hackage.haskell.org/package/base-4.10.0.0/docs/Data-Bifunctor.html#v:first)
+ * - Rust: [Result.map](https://doc.rust-lang.org/std/result/enum.Result.html#method.map)
+ */
+inline infix fun <V, E, U> Result<V, E>.andThenMap(transform: V.() -> U): Result<U, E> =
+    map(transform)

--- a/src/test/kotlin/com/github/michaelbull/result/AndTest.kt
+++ b/src/test/kotlin/com/github/michaelbull/result/AndTest.kt
@@ -42,4 +42,57 @@ class AndTest {
             )
         }
     }
+
+    class AndThenRun {
+        @Test
+        fun returnsTransformedValueIfOk() {
+            assertEquals(
+                expected = 12,
+                actual = Ok(5).andThenRun { Ok(this + 7) }.get()
+            )
+        }
+
+        @Test
+        fun returnsErrorIfErr() {
+            assertSame(
+                expected = AndError,
+                actual = Ok(20).andThenRun { Ok(this + 43) }.andThenRun { Err(AndError) }.getError()!!
+            )
+        }
+
+        @Test
+        fun canBeCalledWithMethodCall() {
+            assertEquals(
+                expected = 3,
+                actual = Ok("abc").andThenRun { Ok(length) }.get()
+            )
+        }
+    }
+
+    class AndThenMap {
+        @Test
+        fun returnsTransformedValueIfOk() {
+            assertEquals(
+                expected = 12,
+                actual = Ok(5).andThenMap { this + 7 }.get()
+            )
+        }
+
+        @Test
+        fun returnsErrorIfErr() {
+            val functionWithError : (Int) -> Result <String, Any> =  { Err(AndError) }
+            assertSame(
+                expected = AndError,
+                actual = Ok(20).andThen(functionWithError).andThenMap { this + 43 }.getError()!!
+            )
+        }
+
+        @Test
+        fun canBeCalledWithMethodCall() {
+            assertEquals(
+                expected = 3,
+                actual = Ok("abc").andThenMap { length }.get()
+            )
+        }
+    }
 }


### PR DESCRIPTION
 Added `andThenRun` and `andThenMap` that are the equivalent of `andThen` and `map`  but using a lambda with receiver.