### PR TITLE
Make BindingTest agnostic of target platform 

### DIFF
--- a/src/test/kotlin/com/github/michaelbull/result/BindingTest.kt
+++ b/src/test/kotlin/com/github/michaelbull/result/BindingTest.kt
@@ -1,6 +1,6 @@
 package com.github.michaelbull.result
 
-import org.junit.Test
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 


### PR DESCRIPTION
by using kotlin test instead of junit test annotation