### PR TITLE
add separate benchmark to compare the different implementations of binding

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,6 +57,9 @@ benchmark {
     targets {
         register("jvmBenchmark")
     }
+
+    // specify via regex to run specific Benchmark classes, e.g. include("BindingBenchmark")
+    configurations["main"].include(".*")
 }
 
 kotlin {
@@ -91,7 +94,7 @@ kotlin {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-native:1.3.7")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-native:1.3.8")
             }
         }
 
@@ -112,6 +115,7 @@ kotlin {
             dependsOn(jvmMain)
             dependencies {
                 implementation("org.jetbrains.kotlinx:kotlinx.benchmark.runtime-jvm:0.2.0-dev-8")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.8")
             }
         }
     }

--- a/src/jvmBenchmark/kotlin/com/github/michaelbull/result/SuspendBindingBenchmark.kt
+++ b/src/jvmBenchmark/kotlin/com/github/michaelbull/result/SuspendBindingBenchmark.kt
@@ -1,0 +1,62 @@
+package com.github.michaelbull.result
+
+import kotlinx.coroutines.*
+import org.openjdk.jmh.annotations.*
+import org.openjdk.jmh.infra.Blackhole
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Threads(Threads.MAX)
+class SuspendBindingBenchmark {
+
+    private object Error
+
+    @Benchmark
+    fun nonSuspendableBinding(blackhole: Blackhole) {
+        val result = binding<Int, Error> {
+            val x = provideX().bind()
+            val y = provideY().bind()
+            x + y
+        }
+        blackhole.consume(result)
+    }
+
+    @Benchmark
+    fun suspendableBinding(blackhole: Blackhole) {
+        val result = GlobalScope.async(Dispatchers.Default) {
+            com.github.michaelbull.result.coroutines.binding<Int, Error> {
+                val x = suspendedProvideX().bind()
+                val y = suspendedProvideY().bind()
+                x + y
+            }
+        }
+        runBlocking {
+            blackhole.consume(result.await())
+        }
+    }
+
+    @State(Scope.Thread)
+    private companion object {
+
+        val time = 100L
+
+        private fun provideX(): Result<Int, Error> {
+            Thread.sleep(time)
+            return Ok(1)
+        }
+        private fun provideY(): Result<Int, Error> {
+            Thread.sleep(time)
+            return Ok(2)
+        }
+        private suspend fun suspendedProvideX(): Result<Int, Error> {
+            delay(time)
+            return Ok(1)
+        }
+        private suspend fun suspendedProvideY(): Result<Int, Error> {
+            delay(time)
+            return Ok(2)
+        }
+    }
+
+}


### PR DESCRIPTION
Basically shows that the binding function has same performance for both implementations (except of course if we use async in the coroutines version, which I added for reference).