### PR TITLE
Concurrent failing binds causes uncaught BindException

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,6 +84,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(kotlin("stdlib-common"))
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-native:1.3.7")
             }
         }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,6 +105,7 @@ kotlin {
             dependencies {
                 implementation(kotlin("test-junit"))
                 implementation(kotlin("test"))
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.8")
             }
         }
 

--- a/src/commonTest/kotlin/com/github/michaelbull/result/coroutines/SuspendableBindingTest.kt
+++ b/src/commonTest/kotlin/com/github/michaelbull/result/coroutines/SuspendableBindingTest.kt
@@ -81,7 +81,7 @@ class SuspendableBindingTest {
 
         suspend fun provideZ(): Result<Int, BindingError> {
             delay(1)
-            return Ok(2)
+            return Err(BindingError)
         }
 
         runBlockingTest {

--- a/src/jvmTest/kotlin/com/github/michaelbull/result/coroutines/AsyncSuspendableBindingTest.kt
+++ b/src/jvmTest/kotlin/com/github/michaelbull/result/coroutines/AsyncSuspendableBindingTest.kt
@@ -1,0 +1,75 @@
+package com.github.michaelbull.result.coroutines
+
+import com.github.michaelbull.result.*
+import kotlinx.coroutines.delay
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.*
+
+class AsyncSuspendableBindingTest {
+
+    private sealed class BindingError {
+        object BindingErrorA: BindingError()
+        object BindingErrorB: BindingError()
+    }
+
+    @Test
+    fun returnsOkIfAllBindsSuccessful() {
+        suspend fun provideX(): Result<Int, BindingError> {
+            delay(100)
+            return Ok(1)
+        }
+
+        suspend fun provideY(): Result<Int, BindingError> {
+            delay(100)
+            return Ok(2)
+        }
+
+        runBlocking {
+            val result = binding<Int, BindingError> {
+                val x = async {provideX().bind()}
+                val y = async {provideY().bind()}
+                x.await() + y.await()
+            }
+            assertTrue(result is Ok)
+            assertEquals(
+                expected = 3,
+                actual = result.value
+            )
+        }
+    }
+
+    @Test
+    fun returnsFirstErrIfBindingFailed() {
+        suspend fun provideX(): Result<Int, BindingError> {
+            delay(1)
+            return Ok(1)
+        }
+
+        suspend fun provideY(): Result<Int, BindingError.BindingErrorA> {
+            delay(2)
+            return Err(BindingError.BindingErrorA)
+        }
+
+        suspend fun provideZ(): Result<Int, BindingError.BindingErrorB> {
+            delay(1)
+            return Err(BindingError.BindingErrorB)
+        }
+
+        runBlocking{
+            val result = binding<Int, BindingError> {
+                val x = async { provideX().bind() }
+                val y = async { provideY().bind() }
+                val z = async { provideZ().bind() }
+                x.await() + y.await() + z.await()
+            }
+
+            assertTrue(result is Err)
+            assertEquals(
+                expected = BindingError.BindingErrorB,
+                actual = result.error
+            )
+        }
+    }
+}


### PR DESCRIPTION
I was adding tests to check which error is returned when multiple binds fail for suspendable binding. I suspected that for async calls that finish closely there could be a race condition and you end up with the error from say, the second failed call instead of the first.

Turns out there is a much bigger problem with implementation for async suspendable functions:

```kt
runBlocking {
            val result = binding<Int, BindingError> {
                val x = async { success().bind() }
                val y = async { fails().bind() } // weird stuff happens here and an uncaught BindException occurs
                val z = async { fails().bind() } 
                x.await() + y.await() + z.await()
            }
}
```

Basically its not behaving with the different coroutines running concurrently. If you step through the test I've added `returnsFirstErrIfBindingFailed()` you'll see what I mean.
Struggled to google a solution to this that could contain this to inside `binding`.
[This thread](https://github.com/Kotlin/kotlinx.coroutines/issues/763#issuecomment-615202690) with an answer from Roman I thought would do the trick but still not working.
CompletableDeferred might also be a solution but not sure how to incorporate it for this case.

I tried a bunch of solutions. Mainly around seeing was there a hack I could implement creating a second `ResultBinding` implementation for `SuspendableBinding`. No luck. All out of ideas right now so hoping others can help jump on this 😄 