### PR TITLE
More Kotlin1.4 migration things

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,6 +64,7 @@ subprojects {
             }
 
             configure<KotlinMultiplatformExtension> {
+                explicitApi()
                 jvm {
                     mavenPublication {
                         artifact(javadocJar.get())

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -2,7 +2,7 @@ object Versions {
     const val dokka = "0.10.1"
     const val kotlin = "1.4.0"
     const val kotlinBenchmark = "0.2.0-dev-20"
-    const val kotlinCoroutines = "1.3.8"
+    const val kotlinCoroutines = "1.3.9"
     const val ktor = "1.4.0"
     const val logback = "1.2.3"
     const val releasePlugin = "2.8.1"

--- a/kotlin-result-coroutines/build.gradle.kts
+++ b/kotlin-result-coroutines/build.gradle.kts
@@ -15,8 +15,7 @@ kotlin {
 
         val commonMain by getting {
             dependencies {
-                implementation(kotlin("stdlib-common"))
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-native:${Versions.kotlinCoroutines}")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.kotlinCoroutines}")
                 implementation(project(":kotlin-result"))
             }
         }
@@ -25,7 +24,6 @@ kotlin {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-native:${Versions.kotlinCoroutines}")
             }
         }
 
@@ -33,7 +31,6 @@ kotlin {
             dependencies {
                 implementation(kotlin("test-junit"))
                 implementation(kotlin("test"))
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.kotlinCoroutines}")
             }
         }
     }

--- a/kotlin-result-coroutines/src/commonMain/kotlin/com/github/michaelbull/result/coroutines/binding/SuspendableBinding.kt
+++ b/kotlin-result-coroutines/src/commonMain/kotlin/com/github/michaelbull/result/coroutines/binding/SuspendableBinding.kt
@@ -12,7 +12,7 @@ import kotlin.contracts.contract
 /**
  * Suspending variant of [binding][com.github.michaelbull.result.binding].
  */
-suspend inline fun <V, E> binding(crossinline block: suspend SuspendableResultBinding<E>.() -> V): Result<V, E> {
+public suspend inline fun <V, E> binding(crossinline block: suspend SuspendableResultBinding<E>.() -> V): Result<V, E> {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
     }
@@ -28,8 +28,8 @@ suspend inline fun <V, E> binding(crossinline block: suspend SuspendableResultBi
 
 internal object BindCancellationException : CancellationException(null)
 
-interface SuspendableResultBinding<E> {
-    suspend fun <V> Result<V, E>.bind(): V
+public interface SuspendableResultBinding<E> {
+    public suspend fun <V> Result<V, E>.bind(): V
 }
 
 @PublishedApi

--- a/kotlin-result/build.gradle.kts
+++ b/kotlin-result/build.gradle.kts
@@ -38,12 +38,6 @@ kotlin {
             }
         }
 
-        val commonMain by getting {
-            dependencies {
-                implementation(kotlin("stdlib-common"))
-            }
-        }
-
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test-common"))
@@ -52,9 +46,6 @@ kotlin {
         }
 
         val jvmMain by getting {
-            dependencies {
-                implementation(kotlin("stdlib-jdk8"))
-            }
         }
 
         val jvmTest by getting {
@@ -67,7 +58,7 @@ kotlin {
         val jvmBenchmark by getting {
             dependsOn(jvmMain)
             dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx.benchmark.runtime-jvm:${Versions.kotlinBenchmark}")
+                implementation("org.jetbrains.kotlinx:kotlinx.benchmark.runtime:${Versions.kotlinBenchmark}")
             }
         }
     }

--- a/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/And.kt
+++ b/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/And.kt
@@ -8,7 +8,7 @@ import kotlin.contracts.contract
  *
  * - Rust: [Result.and](https://doc.rust-lang.org/std/result/enum.Result.html#method.and)
  */
-infix fun <V, E> Result<V, E>.and(result: Result<V, E>): Result<V, E> {
+public infix fun <V, E> Result<V, E>.and(result: Result<V, E>): Result<V, E> {
     return when (this) {
         is Ok -> result
         is Err -> this
@@ -16,7 +16,7 @@ infix fun <V, E> Result<V, E>.and(result: Result<V, E>): Result<V, E> {
 }
 
 @Deprecated("Use andThen instead", ReplaceWith("andThen { result() }"))
-inline infix fun <V, E> Result<V, E>.and(result: () -> Result<V, E>): Result<V, E> {
+public inline infix fun <V, E> Result<V, E>.and(result: () -> Result<V, E>): Result<V, E> {
     contract {
         callsInPlace(result, InvocationKind.AT_MOST_ONCE)
     }
@@ -31,7 +31,7 @@ inline infix fun <V, E> Result<V, E>.and(result: () -> Result<V, E>): Result<V, 
  * - Elm: [Result.andThen](http://package.elm-lang.org/packages/elm-lang/core/latest/Result#andThen)
  * - Rust: [Result.and_then](https://doc.rust-lang.org/std/result/enum.Result.html#method.and_then)
  */
-inline infix fun <V, E, U> Result<V, E>.andThen(transform: (V) -> Result<U, E>): Result<U, E> {
+public inline infix fun <V, E, U> Result<V, E>.andThen(transform: (V) -> Result<U, E>): Result<U, E> {
     contract {
         callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
     }

--- a/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Binding.kt
+++ b/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Binding.kt
@@ -24,7 +24,7 @@ import kotlin.contracts.contract
  *
  * @sample com.github.michaelbull.result.BindingTest
  */
-inline fun <V, E> binding(crossinline block: ResultBinding<E>.() -> V): Result<V, E> {
+public inline fun <V, E> binding(crossinline block: ResultBinding<E>.() -> V): Result<V, E> {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
     }
@@ -40,8 +40,8 @@ inline fun <V, E> binding(crossinline block: ResultBinding<E>.() -> V): Result<V
 
 internal expect object BindException : Exception
 
-interface ResultBinding<E> {
-    fun <V> Result<V, E>.bind(): V
+public interface ResultBinding<E> {
+    public fun <V> Result<V, E>.bind(): V
 }
 
 @PublishedApi

--- a/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Factory.kt
+++ b/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Factory.kt
@@ -8,7 +8,7 @@ import kotlin.contracts.contract
  * invocation was successful, catching and encapsulating any thrown exception
  * as a failure.
  */
-inline fun <V> runCatching(block: () -> V): Result<V, Throwable> {
+public inline fun <V> runCatching(block: () -> V): Result<V, Throwable> {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
     }
@@ -25,7 +25,7 @@ inline fun <V> runCatching(block: () -> V): Result<V, Throwable> {
  * returns its encapsulated result if invocation was successful, catching and
  * encapsulating any thrown exception as a failure.
  */
-inline infix fun <T, V> T.runCatching(block: T.() -> V): Result<V, Throwable> {
+public inline infix fun <T, V> T.runCatching(block: T.() -> V): Result<V, Throwable> {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
     }
@@ -41,7 +41,7 @@ inline infix fun <T, V> T.runCatching(block: T.() -> V): Result<V, Throwable> {
  * Converts a nullable of type [V] to a [Result]. Returns [Ok] if the value is
  * non-null, otherwise the supplied [error].
  */
-inline infix fun <V, E> V?.toResultOr(error: () -> E): Result<V, E> {
+public inline infix fun <V, E> V?.toResultOr(error: () -> E): Result<V, E> {
     contract {
         callsInPlace(error, InvocationKind.AT_MOST_ONCE)
     }

--- a/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Get.kt
+++ b/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Get.kt
@@ -9,7 +9,7 @@ import kotlin.contracts.contract
  * - Elm: [Result.toMaybe](http://package.elm-lang.org/packages/elm-lang/core/latest/Result#toMaybe)
  * - Rust: [Result.ok](https://doc.rust-lang.org/std/result/enum.Result.html#method.ok)
  */
-fun <V, E> Result<V, E>.get(): V? {
+public fun <V, E> Result<V, E>.get(): V? {
     contract {
         returnsNotNull() implies (this@get is Ok<V>)
         returns(null) implies (this@get is Err<E>)
@@ -26,7 +26,7 @@ fun <V, E> Result<V, E>.get(): V? {
  *
  * - Rust: [Result.err](https://doc.rust-lang.org/std/result/enum.Result.html#method.err)
  */
-fun <V, E> Result<V, E>.getError(): E? {
+public fun <V, E> Result<V, E>.getError(): E? {
     contract {
         returns(null) implies (this@getError is Ok<V>)
         returnsNotNull() implies (this@getError is Err<E>)
@@ -48,7 +48,7 @@ fun <V, E> Result<V, E>.getError(): E? {
  * @param default The value to return if [Err].
  * @return The [value][Ok.value] if [Ok], otherwise [default].
  */
-infix fun <V, E> Result<V, E>.getOr(default: V): V {
+public infix fun <V, E> Result<V, E>.getOr(default: V): V {
     return when (this) {
         is Ok -> value
         is Err -> default
@@ -56,7 +56,7 @@ infix fun <V, E> Result<V, E>.getOr(default: V): V {
 }
 
 @Deprecated("Use getOrElse instead", ReplaceWith("getOrElse { default() }"))
-inline infix fun <V, E> Result<V, E>.getOr(default: () -> V): V {
+public inline infix fun <V, E> Result<V, E>.getOr(default: () -> V): V {
     contract {
         callsInPlace(default, InvocationKind.AT_MOST_ONCE)
     }
@@ -72,7 +72,7 @@ inline infix fun <V, E> Result<V, E>.getOr(default: () -> V): V {
  * @param default The error to return if [Ok].
  * @return The [error][Err.error] if [Err], otherwise [default].
  */
-infix fun <V, E> Result<V, E>.getErrorOr(default: E): E {
+public infix fun <V, E> Result<V, E>.getErrorOr(default: E): E {
     return when (this) {
         is Ok -> default
         is Err -> error
@@ -80,7 +80,7 @@ infix fun <V, E> Result<V, E>.getErrorOr(default: E): E {
 }
 
 @Deprecated("Use getOrElse instead", ReplaceWith("getErrorOrElse { default() }"))
-inline infix fun <V, E> Result<V, E>.getErrorOr(default: () -> E): E {
+public inline infix fun <V, E> Result<V, E>.getErrorOr(default: () -> E): E {
     contract {
         callsInPlace(default, InvocationKind.AT_MOST_ONCE)
     }
@@ -95,7 +95,7 @@ inline infix fun <V, E> Result<V, E>.getErrorOr(default: () -> E): E {
  * - Elm: [Result.extract](http://package.elm-lang.org/packages/elm-community/result-extra/2.2.0/Result-Extra#extract)
  * - Rust: [Result.unwrap_or_else](https://doc.rust-lang.org/src/core/result.rs.html#735-740)
  */
-inline infix fun <V, E> Result<V, E>.getOrElse(transform: (E) -> V): V {
+public inline infix fun <V, E> Result<V, E>.getOrElse(transform: (E) -> V): V {
     contract {
         callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
     }
@@ -110,7 +110,7 @@ inline infix fun <V, E> Result<V, E>.getOrElse(transform: (E) -> V): V {
  * Returns the [error][Err.error] if this [Result] is [Err], otherwise the
  * [transformation][transform] of the [value][Ok.value].
  */
-inline infix fun <V, E> Result<V, E>.getErrorOrElse(transform: (V) -> E): E {
+public inline infix fun <V, E> Result<V, E>.getErrorOrElse(transform: (V) -> E): E {
     contract {
         callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
     }
@@ -127,7 +127,7 @@ inline infix fun <V, E> Result<V, E>.getErrorOrElse(transform: (V) -> E): E {
  *
  * - Scala: [MergeableEither.merge](https://www.scala-lang.org/api/2.12.0/scala/util/Either$$MergeableEither.html#merge:A)
  */
-fun <V : U, E : U, U> Result<V, E>.merge(): U {
+public fun <V : U, E : U, U> Result<V, E>.merge(): U {
     return when (this) {
         is Ok -> value
         is Err -> error

--- a/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Iterable.kt
+++ b/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Iterable.kt
@@ -4,7 +4,7 @@ package com.github.michaelbull.result
  * Accumulates value starting with [initial] value and applying [operation] from left to right to
  * current accumulator value and each element.
  */
-inline fun <T, R, E> Iterable<T>.fold(initial: R, operation: (acc: R, T) -> Result<R, E>): Result<R, E> {
+public inline fun <T, R, E> Iterable<T>.fold(initial: R, operation: (acc: R, T) -> Result<R, E>): Result<R, E> {
     var accumulator = initial
 
     for (element in this) {
@@ -21,7 +21,7 @@ inline fun <T, R, E> Iterable<T>.fold(initial: R, operation: (acc: R, T) -> Resu
  * Accumulates value starting with [initial] value and applying [operation] from right to left to
  * each element and current accumulator value.
  */
-inline fun <T, R, E> List<T>.foldRight(initial: R, operation: (T, acc: R) -> Result<R, E>): Result<R, E> {
+public inline fun <T, R, E> List<T>.foldRight(initial: R, operation: (T, acc: R) -> Result<R, E>): Result<R, E> {
     var accumulator = initial
 
     if (!isEmpty()) {
@@ -42,7 +42,7 @@ inline fun <T, R, E> List<T>.foldRight(initial: R, operation: (T, acc: R) -> Res
  *
  * - Elm: [Result.Extra.combine](http://package.elm-lang.org/packages/elm-community/result-extra/2.2.0/Result-Extra#combine)
  */
-fun <V, E> combine(vararg results: Result<V, E>): Result<List<V>, E> {
+public fun <V, E> combine(vararg results: Result<V, E>): Result<List<V>, E> {
     return results.asIterable().combine()
 }
 
@@ -51,7 +51,7 @@ fun <V, E> combine(vararg results: Result<V, E>): Result<List<V>, E> {
  *
  * - Elm: [Result.Extra.combine](http://package.elm-lang.org/packages/elm-community/result-extra/2.2.0/Result-Extra#combine)
  */
-fun <V, E> Iterable<Result<V, E>>.combine(): Result<List<V>, E> {
+public fun <V, E> Iterable<Result<V, E>>.combine(): Result<List<V>, E> {
     return Ok(map {
         when (it) {
             is Ok -> it.value
@@ -66,7 +66,7 @@ fun <V, E> Iterable<Result<V, E>>.combine(): Result<List<V>, E> {
  *
  * - Haskell: [Data.Either.lefts](https://hackage.haskell.org/package/base-4.10.0.0/docs/Data-Either.html#v:lefts)
  */
-fun <V, E> getAll(vararg results: Result<V, E>): List<V> {
+public fun <V, E> getAll(vararg results: Result<V, E>): List<V> {
     return results.asIterable().getAll()
 }
 
@@ -76,7 +76,7 @@ fun <V, E> getAll(vararg results: Result<V, E>): List<V> {
  *
  * - Haskell: [Data.Either.lefts](https://hackage.haskell.org/package/base-4.10.0.0/docs/Data-Either.html#v:lefts)
  */
-fun <V, E> Iterable<Result<V, E>>.getAll(): List<V> {
+public fun <V, E> Iterable<Result<V, E>>.getAll(): List<V> {
     return filterIsInstance<Ok<V>>().map { it.value }
 }
 
@@ -86,7 +86,7 @@ fun <V, E> Iterable<Result<V, E>>.getAll(): List<V> {
  *
  * - Haskell: [Data.Either.rights](https://hackage.haskell.org/package/base-4.10.0.0/docs/Data-Either.html#v:rights)
  */
-fun <V, E> getAllErrors(vararg results: Result<V, E>) = results.asIterable().getAllErrors()
+public fun <V, E> getAllErrors(vararg results: Result<V, E>): List<E> = results.asIterable().getAllErrors()
 
 /**
  * Extracts from an [Iterable] of [Results][Result] all the [Err] elements. All the [Err] elements
@@ -94,7 +94,7 @@ fun <V, E> getAllErrors(vararg results: Result<V, E>) = results.asIterable().get
  *
  * - Haskell: [Data.Either.rights](https://hackage.haskell.org/package/base-4.10.0.0/docs/Data-Either.html#v:rights)
  */
-fun <V, E> Iterable<Result<V, E>>.getAllErrors(): List<E> {
+public fun <V, E> Iterable<Result<V, E>>.getAllErrors(): List<E> {
     return filterIsInstance<Err<E>>().map { it.error }
 }
 
@@ -105,7 +105,7 @@ fun <V, E> Iterable<Result<V, E>>.getAllErrors(): List<E> {
  *
  * - Haskell: [Data.Either.partitionEithers](https://hackage.haskell.org/package/base-4.10.0.0/docs/Data-Either.html#v:partitionEithers)
  */
-fun <V, E> partition(vararg results: Result<V, E>): Pair<List<V>, List<E>> {
+public fun <V, E> partition(vararg results: Result<V, E>): Pair<List<V>, List<E>> {
     return results.asIterable().partition()
 }
 
@@ -116,7 +116,7 @@ fun <V, E> partition(vararg results: Result<V, E>): Pair<List<V>, List<E>> {
  *
  * - Haskell: [Data.Either.partitionEithers](https://hackage.haskell.org/package/base-4.10.0.0/docs/Data-Either.html#v:partitionEithers)
  */
-fun <V, E> Iterable<Result<V, E>>.partition(): Pair<List<V>, List<E>> {
+public fun <V, E> Iterable<Result<V, E>>.partition(): Pair<List<V>, List<E>> {
     val values = mutableListOf<V>()
     val errors = mutableListOf<E>()
 
@@ -135,7 +135,7 @@ fun <V, E> Iterable<Result<V, E>>.partition(): Pair<List<V>, List<E>> {
  * function to each element in the original collection, returning early with the first [Err] if a
  * transformation fails.
  */
-inline fun <V, E, U> Iterable<V>.mapResult(
+public inline fun <V, E, U> Iterable<V>.mapResult(
     transform: (V) -> Result<U, E>
 ): Result<List<U>, E> {
     return Ok(map { element ->
@@ -151,7 +151,7 @@ inline fun <V, E, U> Iterable<V>.mapResult(
  * the results to the given [destination], returning early with the first [Err] if a
  * transformation fails.
  */
-inline fun <V, E, U, C : MutableCollection<in U>> Iterable<V>.mapResultTo(
+public inline fun <V, E, U, C : MutableCollection<in U>> Iterable<V>.mapResultTo(
     destination: C,
     transform: (V) -> Result<U, E>
 ): Result<C, E> {
@@ -168,7 +168,7 @@ inline fun <V, E, U, C : MutableCollection<in U>> Iterable<V>.mapResultTo(
  * given [transform] function to each element in the original collection, returning early with the
  * first [Err] if a transformation fails.
  */
-inline fun <V, E, U : Any> Iterable<V>.mapResultNotNull(
+public inline fun <V, E, U : Any> Iterable<V>.mapResultNotNull(
     transform: (V) -> Result<U, E>?
 ): Result<List<U>, E> {
     return Ok(mapNotNull { element ->
@@ -185,7 +185,7 @@ inline fun <V, E, U : Any> Iterable<V>.mapResultNotNull(
  * only the non-null results to the given [destination], returning early with the first [Err] if a
  * transformation fails.
  */
-inline fun <V, E, U : Any, C : MutableCollection<in U>> Iterable<V>.mapResultNotNullTo(
+public inline fun <V, E, U : Any, C : MutableCollection<in U>> Iterable<V>.mapResultNotNullTo(
     destination: C,
     transform: (V) -> Result<U, E>?
 ): Result<C, E> {
@@ -203,7 +203,7 @@ inline fun <V, E, U : Any, C : MutableCollection<in U>> Iterable<V>.mapResultNot
  * function to each element and its index in the original collection, returning early with the
  * first [Err] if a transformation fails.
  */
-inline fun <V, E, U> Iterable<V>.mapResultIndexed(
+public inline fun <V, E, U> Iterable<V>.mapResultIndexed(
     transform: (index: Int, V) -> Result<U, E>
 ): Result<List<U>, E> {
     return Ok(mapIndexed { index, element ->
@@ -219,7 +219,7 @@ inline fun <V, E, U> Iterable<V>.mapResultIndexed(
  * and appends the results to the given [destination], returning early with the first [Err] if a
  * transformation fails.
  */
-inline fun <V, E, U, C : MutableCollection<in U>> Iterable<V>.mapResultIndexedTo(
+public inline fun <V, E, U, C : MutableCollection<in U>> Iterable<V>.mapResultIndexedTo(
     destination: C,
     transform: (index: Int, V) -> Result<U, E>
 ): Result<C, E> {
@@ -236,7 +236,7 @@ inline fun <V, E, U, C : MutableCollection<in U>> Iterable<V>.mapResultIndexedTo
  * given [transform] function to each element and its index in the original collection, returning
  * early with the first [Err] if a transformation fails.
  */
-inline fun <V, E, U : Any> Iterable<V>.mapResultIndexedNotNull(
+public inline fun <V, E, U : Any> Iterable<V>.mapResultIndexedNotNull(
     transform: (index: Int, V) -> Result<U, E>?
 ): Result<List<U>, E> {
     return Ok(mapIndexedNotNull { index, element ->
@@ -253,7 +253,7 @@ inline fun <V, E, U : Any> Iterable<V>.mapResultIndexedNotNull(
  * and appends only the non-null results to the given [destination], returning early with the first
  * [Err] if a transformation fails.
  */
-inline fun <V, E, U : Any, C : MutableCollection<in U>> Iterable<V>.mapResultIndexedNotNullTo(
+public inline fun <V, E, U : Any, C : MutableCollection<in U>> Iterable<V>.mapResultIndexedNotNullTo(
     destination: C,
     transform: (index: Int, V) -> Result<U, E>?
 ): Result<C, E> {

--- a/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Map.kt
+++ b/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Map.kt
@@ -11,7 +11,7 @@ import kotlin.contracts.contract
  * - Haskell: [Data.Bifunctor.first](https://hackage.haskell.org/package/base-4.10.0.0/docs/Data-Bifunctor.html#v:first)
  * - Rust: [Result.map](https://doc.rust-lang.org/std/result/enum.Result.html#method.map)
  */
-inline infix fun <V, E, U> Result<V, E>.map(transform: (V) -> U): Result<U, E> {
+public inline infix fun <V, E, U> Result<V, E>.map(transform: (V) -> U): Result<U, E> {
     contract {
         callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
     }
@@ -30,7 +30,7 @@ inline infix fun <V, E, U> Result<V, E>.map(transform: (V) -> U): Result<U, E> {
  * - Haskell: [Data.Bifunctor.right](https://hackage.haskell.org/package/base-4.10.0.0/docs/Data-Bifunctor.html#v:second)
  * - Rust: [Result.map_err](https://doc.rust-lang.org/std/result/enum.Result.html#method.map_err)
  */
-inline infix fun <V, E, F> Result<V, E>.mapError(transform: (E) -> F): Result<V, F> {
+public inline infix fun <V, E, F> Result<V, E>.mapError(transform: (E) -> F): Result<V, F> {
     contract {
         callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
     }
@@ -48,7 +48,7 @@ inline infix fun <V, E, F> Result<V, E>.mapError(transform: (E) -> F): Result<V,
  *
  * - Rust: [Result.map_or](https://doc.rust-lang.org/std/result/enum.Result.html#method.map_or)
  */
-inline fun <V, E, U> Result<V, E>.mapOr(default: U, transform: (V) -> U): U {
+public inline fun <V, E, U> Result<V, E>.mapOr(default: U, transform: (V) -> U): U {
     contract {
         callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
     }
@@ -66,7 +66,7 @@ inline fun <V, E, U> Result<V, E>.mapOr(default: U, transform: (V) -> U): U {
  *
  * - Rust: [Result.map_or_else](https://doc.rust-lang.org/std/result/enum.Result.html#method.map_or_else)
  */
-inline fun <V, E, U> Result<V, E>.mapOrElse(default: (E) -> U, transform: (V) -> U): U {
+public inline fun <V, E, U> Result<V, E>.mapOrElse(default: (E) -> U, transform: (V) -> U): U {
     contract {
         callsInPlace(default, InvocationKind.AT_MOST_ONCE)
         callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
@@ -83,7 +83,7 @@ inline fun <V, E, U> Result<V, E>.mapOrElse(default: (E) -> U, transform: (V) ->
  * function to each element in the original collection, returning early with the first [Err] if a
  * transformation fails.
  */
-inline infix fun <V, E, U> Result<Iterable<V>, E>.mapAll(transform: (V) -> Result<U, E>): Result<List<U>, E> {
+public inline infix fun <V, E, U> Result<Iterable<V>, E>.mapAll(transform: (V) -> Result<U, E>): Result<List<U>, E> {
     return map { iterable ->
         iterable.map { element ->
             when (val transformed = transform(element)) {
@@ -102,7 +102,7 @@ inline infix fun <V, E, U> Result<Iterable<V>, E>.mapAll(transform: (V) -> Resul
  * - Elm: [Result.Extra.mapBoth](http://package.elm-lang.org/packages/elm-community/result-extra/2.2.0/Result-Extra#mapBoth)
  * - Haskell: [Data.Either.either](https://hackage.haskell.org/package/base-4.10.0.0/docs/Data-Either.html#v:either)
  */
-inline fun <V, E, U> Result<V, E>.mapBoth(success: (V) -> U, failure: (E) -> U): U {
+public inline fun <V, E, U> Result<V, E>.mapBoth(success: (V) -> U, failure: (E) -> U): U {
     contract {
         callsInPlace(success, InvocationKind.AT_MOST_ONCE)
         callsInPlace(failure, InvocationKind.AT_MOST_ONCE)
@@ -124,7 +124,7 @@ inline fun <V, E, U> Result<V, E>.mapBoth(success: (V) -> U, failure: (E) -> U):
  * - Elm: [Result.Extra.mapBoth](http://package.elm-lang.org/packages/elm-community/result-extra/2.2.0/Result-Extra#mapBoth)
  * - Haskell: [Data.Either.either](https://hackage.haskell.org/package/base-4.10.0.0/docs/Data-Either.html#v:either)
  */
-inline fun <V, E, U> Result<V, E>.fold(success: (V) -> U, failure: (E) -> U): U {
+public inline fun <V, E, U> Result<V, E>.fold(success: (V) -> U, failure: (E) -> U): U {
     contract {
         callsInPlace(success, InvocationKind.AT_MOST_ONCE)
         callsInPlace(failure, InvocationKind.AT_MOST_ONCE)
@@ -139,7 +139,7 @@ inline fun <V, E, U> Result<V, E>.fold(success: (V) -> U, failure: (E) -> U): U 
  *
  * - Haskell: [Data.Bifunctor.Bimap](https://hackage.haskell.org/package/base-4.10.0.0/docs/Data-Bifunctor.html#v:bimap)
  */
-inline fun <V, E, U, F> Result<V, E>.mapEither(success: (V) -> U, failure: (E) -> F): Result<U, F> {
+public inline fun <V, E, U, F> Result<V, E>.mapEither(success: (V) -> U, failure: (E) -> F): Result<U, F> {
     contract {
         callsInPlace(success, InvocationKind.AT_MOST_ONCE)
         callsInPlace(failure, InvocationKind.AT_MOST_ONCE)
@@ -159,7 +159,7 @@ inline fun <V, E, U, F> Result<V, E>.mapEither(success: (V) -> U, failure: (E) -
  *
  * - Scala: [Either.flatMap](http://www.scala-lang.org/api/2.12.0/scala/util/Either.html#flatMap[AA>:A,Y](f:B=>scala.util.Either[AA,Y]):scala.util.Either[AA,Y])
  */
-inline infix fun <V, E, U> Result<V, E>.flatMap(transform: (V) -> Result<U, E>): Result<U, E> {
+public inline infix fun <V, E, U> Result<V, E>.flatMap(transform: (V) -> Result<U, E>): Result<U, E> {
     contract {
         callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
     }
@@ -173,7 +173,7 @@ inline infix fun <V, E, U> Result<V, E>.flatMap(transform: (V) -> Result<U, E>):
  *
  * @see [takeIf]
  */
-inline fun <V, E> Result<V, E>.toErrorIf(predicate: (V) -> Boolean, transform: (V) -> E): Result<V, E> {
+public inline fun <V, E> Result<V, E>.toErrorIf(predicate: (V) -> Boolean, transform: (V) -> E): Result<V, E> {
     contract {
         callsInPlace(predicate, InvocationKind.AT_MOST_ONCE)
         callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
@@ -195,7 +195,7 @@ inline fun <V, E> Result<V, E>.toErrorIf(predicate: (V) -> Boolean, transform: (
  *
  * @see [takeUnless]
  */
-inline fun <V, E> Result<V, E>.toErrorUnless(predicate: (V) -> Boolean, transform: (V) -> E): Result<V, E> {
+public inline fun <V, E> Result<V, E>.toErrorUnless(predicate: (V) -> Boolean, transform: (V) -> E): Result<V, E> {
     contract {
         callsInPlace(predicate, InvocationKind.AT_MOST_ONCE)
         callsInPlace(transform, InvocationKind.AT_MOST_ONCE)

--- a/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/On.kt
+++ b/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/On.kt
@@ -6,7 +6,7 @@ import kotlin.contracts.contract
 /**
  * Invokes an [action] if this [Result] is [Ok].
  */
-inline infix fun <V, E> Result<V, E>.onSuccess(action: (V) -> Unit): Result<V, E> {
+public inline infix fun <V, E> Result<V, E>.onSuccess(action: (V) -> Unit): Result<V, E> {
     contract {
         callsInPlace(action, InvocationKind.AT_MOST_ONCE)
     }
@@ -21,7 +21,7 @@ inline infix fun <V, E> Result<V, E>.onSuccess(action: (V) -> Unit): Result<V, E
 /**
  * Invokes an [action] if this [Result] is [Err].
  */
-inline infix fun <V, E> Result<V, E>.onFailure(action: (E) -> Unit): Result<V, E> {
+public inline infix fun <V, E> Result<V, E>.onFailure(action: (E) -> Unit): Result<V, E> {
     contract {
         callsInPlace(action, InvocationKind.AT_MOST_ONCE)
     }

--- a/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Or.kt
+++ b/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Or.kt
@@ -8,7 +8,7 @@ import kotlin.contracts.contract
  *
  * - Rust: [Result.or](https://doc.rust-lang.org/std/result/enum.Result.html#method.or)
  */
-infix fun <V, E> Result<V, E>.or(result: Result<V, E>): Result<V, E> {
+public infix fun <V, E> Result<V, E>.or(result: Result<V, E>): Result<V, E> {
     return when (this) {
         is Ok -> this
         is Err -> result
@@ -16,7 +16,7 @@ infix fun <V, E> Result<V, E>.or(result: Result<V, E>): Result<V, E> {
 }
 
 @Deprecated("Use orElse instead", ReplaceWith("orElse { result() }"))
-inline infix fun <V, E> Result<V, E>.or(result: () -> Result<V, E>): Result<V, E> {
+public inline infix fun <V, E> Result<V, E>.or(result: () -> Result<V, E>): Result<V, E> {
     contract {
         callsInPlace(result, InvocationKind.AT_MOST_ONCE)
     }
@@ -30,7 +30,7 @@ inline infix fun <V, E> Result<V, E>.or(result: () -> Result<V, E>): Result<V, E
  *
  * - Rust: [Result.or_else](https://doc.rust-lang.org/std/result/enum.Result.html#method.or_else)
  */
-inline infix fun <V, E> Result<V, E>.orElse(transform: (E) -> Result<V, E>): Result<V, E> {
+public inline infix fun <V, E> Result<V, E>.orElse(transform: (E) -> Result<V, E>): Result<V, E> {
     contract {
         callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
     }
@@ -45,7 +45,7 @@ inline infix fun <V, E> Result<V, E>.orElse(transform: (E) -> Result<V, E>): Res
  * Returns the [transformation][transform] of the [error][Err.error] if this [Result] is [Err],
  * otherwise this [Ok].
  */
-inline infix fun <V, E> Result<V, E>.recover(transform: (E) -> V): Ok<V> {
+public inline infix fun <V, E> Result<V, E>.recover(transform: (E) -> V): Ok<V> {
     contract {
         callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
     }

--- a/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Result.kt
+++ b/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Result.kt
@@ -7,19 +7,19 @@ package com.github.michaelbull.result
  * - Haskell: [Data.Either](https://hackage.haskell.org/package/base-4.10.0.0/docs/Data-Either.html)
  * - Rust: [Result](https://doc.rust-lang.org/std/result/enum.Result.html)
  */
-sealed class Result<out V, out E> {
+public sealed class Result<out V, out E> {
 
-    abstract operator fun component1(): V?
-    abstract operator fun component2(): E?
+    public abstract operator fun component1(): V?
+    public abstract operator fun component2(): E?
 
-    companion object {
+    public companion object {
 
         /**
          * Invokes a [function] and wraps it in a [Result], returning an [Err]
          * if an [Exception] was thrown, otherwise [Ok].
          */
         @Deprecated("Use top-level runCatching instead", ReplaceWith("runCatching(function)"))
-        inline fun <V> of(function: () -> V): Result<V, Exception> {
+        public inline fun <V> of(function: () -> V): Result<V, Exception> {
             return try {
                 Ok(function.invoke())
             } catch (ex: Exception) {
@@ -32,10 +32,10 @@ sealed class Result<out V, out E> {
 /**
  * Represents a successful [Result], containing a [value].
  */
-class Ok<out V>(val value: V) : Result<V, Nothing>() {
+public class Ok<out V>(public val value: V) : Result<V, Nothing>() {
 
-    override fun component1() = value
-    override fun component2() = null
+    override fun component1(): V = value
+    override fun component2(): Nothing? = null
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -48,17 +48,17 @@ class Ok<out V>(val value: V) : Result<V, Nothing>() {
         return true
     }
 
-    override fun hashCode() = value.hashCode()
-    override fun toString() = "Ok($value)"
+    override fun hashCode(): Int = value.hashCode()
+    override fun toString(): String = "Ok($value)"
 }
 
 /**
  * Represents a failed [Result], containing an [error].
  */
-class Err<out E>(val error: E) : Result<Nothing, E>() {
+public class Err<out E>(public val error: E) : Result<Nothing, E>() {
 
-    override fun component1() = null
-    override fun component2() = error
+    override fun component1(): Nothing? = null
+    override fun component2(): E = error
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -71,6 +71,6 @@ class Err<out E>(val error: E) : Result<Nothing, E>() {
         return true
     }
 
-    override fun hashCode() = error.hashCode()
-    override fun toString() = "Err($error)"
+    override fun hashCode(): Int = error.hashCode()
+    override fun toString(): String = "Err($error)"
 }

--- a/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/ResultIterator.kt
+++ b/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/ResultIterator.kt
@@ -6,7 +6,7 @@ package com.github.michaelbull.result
  *
  * - Rust: [Result.iter](https://doc.rust-lang.org/std/result/enum.Result.html#method.iter)
  */
-fun <V, E> Result<V, E>.iterator(): Iterator<V> {
+public fun <V, E> Result<V, E>.iterator(): Iterator<V> {
     return ResultIterator(this)
 }
 
@@ -16,7 +16,7 @@ fun <V, E> Result<V, E>.iterator(): Iterator<V> {
  *
  * - Rust: [Result.iter_mut](https://doc.rust-lang.org/std/result/enum.Result.html#method.iter_mut)
  */
-fun <V, E> Result<V, E>.mutableIterator(): MutableIterator<V> {
+public fun <V, E> Result<V, E>.mutableIterator(): MutableIterator<V> {
     return ResultIterator(this)
 }
 

--- a/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Unwrap.kt
+++ b/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Unwrap.kt
@@ -3,7 +3,7 @@ package com.github.michaelbull.result
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
-class UnwrapException(message: String) : Exception(message)
+public class UnwrapException(message: String) : Exception(message)
 
 /**
  * Unwraps a [Result], yielding the [value][Ok.value].
@@ -12,7 +12,7 @@ class UnwrapException(message: String) : Exception(message)
  *
  * @throws UnwrapException if the [Result] is an [Err], with a message containing the [error][Err.error].
  */
-fun <V, E> Result<V, E>.unwrap(): V {
+public fun <V, E> Result<V, E>.unwrap(): V {
     contract {
         returns() implies (this@unwrap is Ok<V>)
     }
@@ -24,7 +24,7 @@ fun <V, E> Result<V, E>.unwrap(): V {
 }
 
 @Deprecated("Use lazy-evaluating variant instead", ReplaceWith("expect { message }"))
-infix fun <V, E> Result<V, E>.expect(message: String): V {
+public infix fun <V, E> Result<V, E>.expect(message: String): V {
     contract {
         returns() implies (this@expect is Ok<V>)
     }
@@ -40,7 +40,7 @@ infix fun <V, E> Result<V, E>.expect(message: String): V {
  * @param message The message to include in the [UnwrapException] if the [Result] is an [Err].
  * @throws UnwrapException if the [Result] is an [Err], with the specified [message].
  */
-inline infix fun <V, E> Result<V, E>.expect(message: () -> Any): V {
+public inline infix fun <V, E> Result<V, E>.expect(message: () -> Any): V {
     contract {
         callsInPlace(message, InvocationKind.AT_MOST_ONCE)
         returns() implies (this@expect is Ok<V>)
@@ -59,7 +59,7 @@ inline infix fun <V, E> Result<V, E>.expect(message: () -> Any): V {
  *
  * @throws UnwrapException if the [Result] is [Ok], with a message containing the [value][Ok.value].
  */
-fun <V, E> Result<V, E>.unwrapError(): E {
+public fun <V, E> Result<V, E>.unwrapError(): E {
     contract {
         returns() implies (this@unwrapError is Err<E>)
     }
@@ -71,7 +71,7 @@ fun <V, E> Result<V, E>.unwrapError(): E {
 }
 
 @Deprecated("Use lazy-evaluating variant instead", ReplaceWith("expectError { message }"))
-infix fun <V, E> Result<V, E>.expectError(message: String): E {
+public infix fun <V, E> Result<V, E>.expectError(message: String): E {
     contract {
         returns() implies (this@expectError is Err<E>)
     }
@@ -87,7 +87,7 @@ infix fun <V, E> Result<V, E>.expectError(message: String): E {
  * @param message The message to include in the [UnwrapException] if the [Result] is [Ok].
  * @throws UnwrapException if the [Result] is [Ok], with the specified [message].
  */
-inline infix fun <V, E> Result<V, E>.expectError(message: () -> Any): E {
+public inline infix fun <V, E> Result<V, E>.expectError(message: () -> Any): E {
     contract {
         callsInPlace(message, InvocationKind.AT_MOST_ONCE)
         returns() implies (this@expectError is Err<E>)

--- a/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Zip.kt
+++ b/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Zip.kt
@@ -11,7 +11,7 @@ private typealias Producer<T, E> = () -> Result<T, E>
  *
  * - Elm: http://package.elm-lang.org/packages/elm-lang/core/latest/Result#map2
  */
-inline fun <T1, T2, E, V> zip(
+public inline fun <T1, T2, E, V> zip(
     result1: Producer<T1, E>,
     result2: Producer<T2, E>,
     transform: (T1, T2) -> V
@@ -35,7 +35,7 @@ inline fun <T1, T2, E, V> zip(
  *
  * - Elm: http://package.elm-lang.org/packages/elm-lang/core/latest/Result#map3
  */
-inline fun <T1, T2, T3, E, V> zip(
+public inline fun <T1, T2, T3, E, V> zip(
     result1: Producer<T1, E>,
     result2: Producer<T2, E>,
     result3: Producer<T3, E>,
@@ -63,7 +63,7 @@ inline fun <T1, T2, T3, E, V> zip(
  *
  * - Elm: http://package.elm-lang.org/packages/elm-lang/core/latest/Result#map4
  */
-inline fun <T1, T2, T3, T4, E, V> zip(
+public inline fun <T1, T2, T3, T4, E, V> zip(
     result1: Producer<T1, E>,
     result2: Producer<T2, E>,
     result3: Producer<T3, E>,
@@ -95,7 +95,7 @@ inline fun <T1, T2, T3, T4, E, V> zip(
  *
  * - Elm: http://package.elm-lang.org/packages/elm-lang/core/latest/Result#map5
  */
-inline fun <T1, T2, T3, T4, T5, E, V> zip(
+public inline fun <T1, T2, T3, T4, T5, E, V> zip(
     result1: Producer<T1, E>,
     result2: Producer<T2, E>,
     result3: Producer<T3, E>,

--- a/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/coroutines/SuspendableBinding.kt
+++ b/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/coroutines/SuspendableBinding.kt
@@ -17,7 +17,7 @@ import kotlin.contracts.contract
         "Please import the kotlin-result-coroutines library to continue using this feature.",
     level = DeprecationLevel.WARNING
 )
-suspend inline fun <V, E> binding(crossinline block: suspend ResultBinding<E>.() -> V): Result<V, E> {
+public suspend inline fun <V, E> binding(crossinline block: suspend ResultBinding<E>.() -> V): Result<V, E> {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
     }


### PR DESCRIPTION
Added `explicitApi()` so publicly exposed api functions needed to be explicitly declared `public` and all required return types.

Removed redundant kotlinx and stdlib dependencies. To do that I actually had to bump coroutines to 1.3.9 (they didn't make that very clear from the changelist 🤔 ).