### PR TITLE
Add JS targets for Kotlin Multiplatform

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,11 @@ subprojects {
                         artifact(javadocJar.get())
                     }
                 }
+
+                js {
+                    browser()
+                    nodejs()
+                }
             }
         }
 

--- a/kotlin-result-coroutines/build.gradle.kts
+++ b/kotlin-result-coroutines/build.gradle.kts
@@ -33,6 +33,12 @@ kotlin {
                 implementation(kotlin("test"))
             }
         }
+
+        val jsTest by getting {
+            dependencies {
+                implementation(kotlin("test-js"))
+            }
+        }
     }
 }
 

--- a/kotlin-result-coroutines/src/commonTest/kotlin/com.github.michaelbull.result.coroutines/binding/SuspendableBindingTest.kt
+++ b/kotlin-result-coroutines/src/commonTest/kotlin/com.github.michaelbull.result.coroutines/binding/SuspendableBindingTest.kt
@@ -25,7 +25,7 @@ class SuspendableBindingTest {
             return Ok(2)
         }
 
-        runBlockingTest {
+        return runBlockingTest {
             val result = binding<Int, BindingError> {
                 val x = provideX().bind()
                 val y = provideY().bind()
@@ -52,7 +52,7 @@ class SuspendableBindingTest {
             return Ok(x + 2)
         }
 
-        runBlockingTest {
+        return runBlockingTest {
             val result = binding<Int, BindingError> {
                 val x = provideX().bind()
                 val y = provideY(x.toInt()).bind()
@@ -84,7 +84,7 @@ class SuspendableBindingTest {
             return Ok(2)
         }
 
-        runBlockingTest {
+        return runBlockingTest {
             val result = binding<Int, BindingError> {
                 val x = provideX().bind()
                 val y = provideY().bind()
@@ -117,7 +117,7 @@ class SuspendableBindingTest {
             return Ok(2)
         }
 
-        runBlockingTest {
+        return runBlockingTest {
             val result = binding<Int, BindingError> {
                 val x = provideX().bind()
                 val y = provideY().bind()

--- a/kotlin-result-coroutines/src/jsTest/kotlin/com.github.michaelbull.result.coroutines/RunBlockingTest.kt
+++ b/kotlin-result-coroutines/src/jsTest/kotlin/com.github.michaelbull.result.coroutines/RunBlockingTest.kt
@@ -1,0 +1,10 @@
+package com.github.michaelbull.result.coroutines
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.promise
+
+import kotlin.coroutines.CoroutineContext
+
+actual fun runBlockingTest(context: CoroutineContext, testBody: suspend CoroutineScope.() -> Unit): dynamic =
+    GlobalScope.promise(context) { testBody(this) }

--- a/kotlin-result-coroutines/src/jsTest/kotlin/com.github.michaelbull.result.coroutines/binding/AsyncSuspendableBindingTests.kt
+++ b/kotlin-result-coroutines/src/jsTest/kotlin/com.github.michaelbull.result.coroutines/binding/AsyncSuspendableBindingTests.kt
@@ -44,7 +44,7 @@ class AsyncSuspendableBindingTest {
     }
 
     @Test
-    fun returnsAnyErrIfBindingFailed() {
+    fun returnsAnyErrIfBindingFailed(): dynamic {
         suspend fun provideX(): Result<Int, BindingError> {
             delay(1)
             return Ok(1)
@@ -60,7 +60,7 @@ class AsyncSuspendableBindingTest {
             return Err(BindingError.BindingErrorB)
         }
 
-        runBlockingTest {
+        return runBlockingTest {
             val result = binding<Int, BindingError> {
                 val x = async { provideX().bind() }
                 val y = async { provideY().bind() }

--- a/kotlin-result-coroutines/src/jsTest/kotlin/com.github.michaelbull.result.coroutines/binding/AsyncSuspendableBindingTests.kt
+++ b/kotlin-result-coroutines/src/jsTest/kotlin/com.github.michaelbull.result.coroutines/binding/AsyncSuspendableBindingTests.kt
@@ -83,13 +83,13 @@ class AsyncSuspendableBindingTest {
         var yStateChange = false
         var zStateChange = false
         suspend fun provideX(): Result<Int, BindingError> {
-            delay(10)
+            delay(20)
             xStateChange = true
             return Ok(1)
         }
 
         suspend fun provideY(): Result<Int, BindingError.BindingErrorA> {
-            delay(20)
+            delay(10)
             yStateChange = true
             return Err(BindingError.BindingErrorA)
         }

--- a/kotlin-result-coroutines/src/jsTest/kotlin/com.github.michaelbull.result.coroutines/binding/AsyncSuspendableBindingTests.kt
+++ b/kotlin-result-coroutines/src/jsTest/kotlin/com.github.michaelbull.result.coroutines/binding/AsyncSuspendableBindingTests.kt
@@ -1,0 +1,45 @@
+package com.github.michaelbull.result.coroutines.binding
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.coroutines.runBlockingTest
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AsyncSuspendableBindingTest {
+
+    private sealed class BindingError {
+        object BindingErrorA : BindingError()
+        object BindingErrorB : BindingError()
+    }
+
+    @Test
+    fun returnsOkIfAllBindsSuccessful(): dynamic {
+        suspend fun provideX(): Result<Int, BindingError> {
+            delay(100)
+            return Ok(1)
+        }
+
+        suspend fun provideY(): Result<Int, BindingError> {
+            delay(100)
+            return Ok(2)
+        }
+
+        return runBlockingTest {
+            val result = binding<Int, BindingError> {
+                val x = async { provideX().bind() }
+                val y = async { provideY().bind() }
+                x.await() + y.await()
+            }
+            assertTrue(result is Ok)
+            assertEquals(
+                expected = 3,
+                actual = result.value
+            )
+        }
+    }
+}

--- a/kotlin-result/build.gradle.kts
+++ b/kotlin-result/build.gradle.kts
@@ -60,6 +60,14 @@ kotlin {
                 implementation("org.jetbrains.kotlinx:kotlinx.benchmark.runtime:${Versions.kotlinBenchmark}")
             }
         }
+
+        val jsMain by getting
+
+        val jsTest by getting {
+            dependencies {
+                implementation(kotlin("test-js"))
+            }
+        }
     }
 }
 

--- a/kotlin-result/src/jsMain/kotlin/com/github/michaelbull/result/BindException.kt
+++ b/kotlin-result/src/jsMain/kotlin/com/github/michaelbull/result/BindException.kt
@@ -1,0 +1,3 @@
+package com.github.michaelbull.result
+
+internal actual object BindException : Exception()


### PR DESCRIPTION
This PR adds two targets for Kotlin/JS, namely browser and nodejs.

Minor changes to the common tests were necessary to ensure that they can fail on the JS platform.
I also left out the ordering test for async suspendable binding due to the single threaded nature of JS.
