### PR TITLE
Eagerly cancel async bindings

### DIFF
--- a/kotlin-result-coroutines/src/commonMain/kotlin/com/github/michaelbull/result/coroutines/binding/SuspendableBinding.kt
+++ b/kotlin-result-coroutines/src/commonMain/kotlin/com/github/michaelbull/result/coroutines/binding/SuspendableBinding.kt
@@ -3,7 +3,10 @@ package com.github.michaelbull.result.coroutines.binding
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlin.contracts.InvocationKind
@@ -12,11 +15,30 @@ import kotlin.contracts.contract
 /**
  * Suspending variant of [binding][com.github.michaelbull.result.binding].
  */
-public suspend inline fun <V, E> binding(eagerlyCancel: Boolean = false, crossinline block: suspend SuspendableResultBinding<E>.() -> V): Result<V, E> {
+public suspend inline fun <V, E> binding(crossinline block: suspend SuspendableResultBinding<E>.() -> V): Result<V, E> {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
     }
-    val receiver = SuspendableResultBindingImpl<E>(eagerlyCancel)
+    val receiver = SuspendableResultBindingImpl<E>(eagerlyCancel = false)
+
+    return try {
+        with(receiver) { Ok(block()) }
+    } catch (ex: BindCancellationException) {
+        receiver.internalError
+    }
+}
+
+/**
+ * For use with [kotlinx.coroutines.async] wrapped binds. Eagerly cancels all deferred jobs once a failing bind is encountered.
+ * A Suspending variant of [binding][com.github.michaelbull.result.binding] that wraps the suspendable block in a new coroutine scope.
+ * When any bind fails in this scope, the coroutine scope will be cancelled which in turn cancels its children.
+ * This can be useful in cases where long running or computation heavy async suspending calls are not needed to complete once the first binding fails.
+ */
+public suspend inline fun <V, E> eagerlyCancelBinding(crossinline block: suspend SuspendableResultBinding<E>.() -> V): Result<V, E> {
+    contract {
+        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+    }
+    val receiver = SuspendableResultBindingImpl<E>(eagerlyCancel = true)
 
     return try {
         coroutineScope {
@@ -26,9 +48,6 @@ public suspend inline fun <V, E> binding(eagerlyCancel: Boolean = false, crossin
     } catch (ex: BindCancellationException) {
         receiver.internalError
     }
-
-
-
 }
 
 internal object BindCancellationException : CancellationException(null)

--- a/kotlin-result-coroutines/src/commonTest/kotlin/com.github.michaelbull.result.coroutines/binding/SuspendableBindingTest.kt
+++ b/kotlin-result-coroutines/src/commonTest/kotlin/com.github.michaelbull.result.coroutines/binding/SuspendableBindingTest.kt
@@ -7,6 +7,7 @@ import com.github.michaelbull.result.coroutines.runBlockingTest
 import kotlinx.coroutines.delay
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class SuspendableBindingTest {
@@ -97,6 +98,90 @@ class SuspendableBindingTest {
                 expected = BindingError,
                 actual = result.error
             )
+        }
+    }
+
+    @Test
+    fun returnsStateChangedUntilFirstBindFailedWhenBindingSetToNotCancelEagerly() {
+        var xStateChange = false
+        var yStateChange = false
+        var zStateChange = false
+        suspend fun provideX(): Result<Int, BindingError> {
+            delay(1)
+            xStateChange = true
+            return Ok(1)
+        }
+
+        suspend fun provideY(): Result<Int, BindingError> {
+            delay(10)
+            yStateChange = true
+            return Err(BindingError)
+        }
+
+        suspend fun provideZ(): Result<Int, BindingError> {
+            delay(1)
+            zStateChange = true
+            return Err(BindingError)
+        }
+
+        runBlockingTest {
+            val result = binding<Int, BindingError>(eagerlyCancel = false) {
+                val x = provideX().bind()
+                val y = provideY().bind()
+                val z = provideZ().bind()
+                x + y + z
+            }
+
+            assertTrue(result is Err)
+            assertEquals(
+                expected = BindingError,
+                actual = result.error
+            )
+            assertTrue(xStateChange)
+            assertTrue(yStateChange)
+            assertFalse(zStateChange)
+        }
+    }
+
+    @Test
+    fun returnsStateChangedUntilFirstBindFailedWhenBindingSetToCancelEagerly() {
+        var xStateChange = false
+        var yStateChange = false
+        var zStateChange = false
+        suspend fun provideX(): Result<Int, BindingError> {
+            delay(1)
+            xStateChange = true
+            return Ok(1)
+        }
+
+        suspend fun provideY(): Result<Int, BindingError> {
+            delay(10)
+            yStateChange = true
+            return Err(BindingError)
+        }
+
+        suspend fun provideZ(): Result<Int, BindingError> {
+            delay(1)
+            zStateChange = true
+            return Err(BindingError)
+        }
+
+        runBlockingTest {
+            val result = binding<Int, BindingError>(eagerlyCancel = true) {
+                val x = provideX().bind()
+                val y = provideY().bind()
+                val z = provideZ().bind()
+                x + y + z
+            }
+
+            assertTrue(result is Err)
+            assertEquals(
+                expected = BindingError,
+                actual = result.error
+            )
+            assertTrue(xStateChange)
+            assertTrue(yStateChange)
+            assertFalse(zStateChange)
         }
     }
 

--- a/kotlin-result-coroutines/src/commonTest/kotlin/com.github.michaelbull.result.coroutines/binding/SuspendableBindingTest.kt
+++ b/kotlin-result-coroutines/src/commonTest/kotlin/com.github.michaelbull.result.coroutines/binding/SuspendableBindingTest.kt
@@ -102,7 +102,7 @@ class SuspendableBindingTest {
     }
 
     @Test
-    fun returnsStateChangedUntilFirstBindFailedWhenBindingSetToNotCancelEagerly() {
+    fun returnsStateChangedUntilFirstBindFailed() {
         var xStateChange = false
         var yStateChange = false
         var zStateChange = false
@@ -125,49 +125,7 @@ class SuspendableBindingTest {
         }
 
         runBlockingTest {
-            val result = binding<Int, BindingError>(eagerlyCancel = false) {
-                val x = provideX().bind()
-                val y = provideY().bind()
-                val z = provideZ().bind()
-                x + y + z
-            }
-
-            assertTrue(result is Err)
-            assertEquals(
-                expected = BindingError,
-                actual = result.error
-            )
-            assertTrue(xStateChange)
-            assertTrue(yStateChange)
-            assertFalse(zStateChange)
-        }
-    }
-
-    @Test
-    fun returnsStateChangedUntilFirstBindFailedWhenBindingSetToCancelEagerly() {
-        var xStateChange = false
-        var yStateChange = false
-        var zStateChange = false
-        suspend fun provideX(): Result<Int, BindingError> {
-            delay(1)
-            xStateChange = true
-            return Ok(1)
-        }
-
-        suspend fun provideY(): Result<Int, BindingError> {
-            delay(10)
-            yStateChange = true
-            return Err(BindingError)
-        }
-
-        suspend fun provideZ(): Result<Int, BindingError> {
-            delay(1)
-            zStateChange = true
-            return Err(BindingError)
-        }
-
-        runBlockingTest {
-            val result = binding<Int, BindingError>(eagerlyCancel = true) {
+            val result = binding<Int, BindingError> {
                 val x = provideX().bind()
                 val y = provideY().bind()
                 val z = provideZ().bind()

--- a/kotlin-result-coroutines/src/jvmTest/kotlin/com/github/michaelbull/result/coroutines/binding/AsyncSuspendableBindingTest.kt
+++ b/kotlin-result-coroutines/src/jvmTest/kotlin/com/github/michaelbull/result/coroutines/binding/AsyncSuspendableBindingTest.kt
@@ -79,7 +79,7 @@ class AsyncSuspendableBindingTest {
     }
 
     @Test
-    fun returnsAllStateChangedIfAnyBindFailedWhenBindingSetToNotCancelEagerly() {
+    fun returnsAllStateChangedIfAnyAsyncBindFailsWhenNotEagerlyCancellingBinding() {
         var xStateChange = false
         var yStateChange = false
         var zStateChange = false
@@ -102,7 +102,7 @@ class AsyncSuspendableBindingTest {
         }
 
         runBlocking {
-            val result = binding<Int, BindingError>(eagerlyCancel = false) {
+            val result = binding<Int, BindingError> {
                 val x = async { provideX().bind() }
                 val y = async { provideY().bind() }
                 val z = async { provideZ().bind() }
@@ -121,7 +121,7 @@ class AsyncSuspendableBindingTest {
     }
 
     @Test
-    fun returnsStateChangedForOnlyTheFirstBindFailedWhenBindingSetToCancelEagerly() {
+    fun returnsStateChangedForOnlyTheFirstAsyncBindFailWhenEagerlyCancellingBinding() {
         var xStateChange = false
         var yStateChange = false
         var zStateChange = false
@@ -144,7 +144,7 @@ class AsyncSuspendableBindingTest {
         }
 
         runBlocking {
-            val result = binding<Int, BindingError>(eagerlyCancel = true) {
+            val result = eagerlyCancelBinding<Int, BindingError> {
                 val x = async { provideX().bind() }
                 val y = async { provideY().bind() }
                 val z = async { provideZ().bind() }

--- a/kotlin-result-coroutines/src/jvmTest/kotlin/com/github/michaelbull/result/coroutines/binding/AsyncSuspendableBindingTest.kt
+++ b/kotlin-result-coroutines/src/jvmTest/kotlin/com/github/michaelbull/result/coroutines/binding/AsyncSuspendableBindingTest.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class AsyncSuspendableBindingTest {
@@ -47,7 +48,7 @@ class AsyncSuspendableBindingTest {
     @Test
     fun returnsFirstErrIfBindingFailed() {
         suspend fun provideX(): Result<Int, BindingError> {
-            delay(1)
+            delay(3)
             return Ok(1)
         }
 
@@ -74,6 +75,90 @@ class AsyncSuspendableBindingTest {
                 expected = BindingError.BindingErrorB,
                 actual = result.error
             )
+        }
+    }
+
+    @Test
+    fun returnsAllStateChangedIfAnyBindFailedWhenBindingSetToNotCancelEagerly() {
+        var xStateChange = false
+        var yStateChange = false
+        var zStateChange = false
+        suspend fun provideX(): Result<Int, BindingError> {
+            delay(3)
+            xStateChange = true
+            return Ok(1)
+        }
+
+        suspend fun provideY(): Result<Int, BindingError.BindingErrorA> {
+            delay(2)
+            yStateChange = true
+            return Err(BindingError.BindingErrorA)
+        }
+
+        suspend fun provideZ(): Result<Int, BindingError.BindingErrorB> {
+            delay(1)
+            zStateChange = true
+            return Err(BindingError.BindingErrorB)
+        }
+
+        runBlocking {
+            val result = binding<Int, BindingError>(eagerlyCancel = false) {
+                val x = async { provideX().bind() }
+                val y = async { provideY().bind() }
+                val z = async { provideZ().bind() }
+                x.await() + y.await() + z.await()
+            }
+
+            assertTrue(result is Err)
+            assertEquals(
+                expected = BindingError.BindingErrorB,
+                actual = result.error
+            )
+            assertTrue(xStateChange)
+            assertTrue(yStateChange)
+            assertTrue(zStateChange)
+        }
+    }
+
+    @Test
+    fun returnsStateChangedForOnlyTheFirstBindFailedWhenBindingSetToCancelEagerly() {
+        var xStateChange = false
+        var yStateChange = false
+        var zStateChange = false
+        suspend fun provideX(): Result<Int, BindingError> {
+            delay(3)
+            xStateChange = true
+            return Ok(1)
+        }
+
+        suspend fun provideY(): Result<Int, BindingError.BindingErrorA> {
+            delay(2)
+            yStateChange = true
+            return Err(BindingError.BindingErrorA)
+        }
+
+        suspend fun provideZ(): Result<Int, BindingError.BindingErrorB> {
+            delay(1)
+            zStateChange = true
+            return Err(BindingError.BindingErrorB)
+        }
+
+        runBlocking {
+            val result = binding<Int, BindingError>(eagerlyCancel = true) {
+                val x = async { provideX().bind() }
+                val y = async { provideY().bind() }
+                val z = async { provideZ().bind() }
+                x.await() + y.await() + z.await()
+            }
+
+            assertTrue(result is Err)
+            assertEquals(
+                expected = BindingError.BindingErrorB,
+                actual = result.error
+            )
+            assertFalse(xStateChange)
+            assertFalse(yStateChange)
+            assertTrue(zStateChange)
         }
     }
 }

--- a/kotlin-result-coroutines/src/jvmTest/kotlin/com/github/michaelbull/result/coroutines/binding/AsyncSuspendableBindingTest.kt
+++ b/kotlin-result-coroutines/src/jvmTest/kotlin/com/github/michaelbull/result/coroutines/binding/AsyncSuspendableBindingTest.kt
@@ -79,18 +79,18 @@ class AsyncSuspendableBindingTest {
     }
 
     @Test
-    fun returnsAllStateChangedIfAnyAsyncBindFailsWhenNotEagerlyCancellingBinding() {
+    fun returnsStateChangedForOnlyTheFirstAsyncBindFailWhenEagerlyCancellingBinding() {
         var xStateChange = false
         var yStateChange = false
         var zStateChange = false
         suspend fun provideX(): Result<Int, BindingError> {
-            delay(3)
+            delay(20)
             xStateChange = true
             return Ok(1)
         }
 
         suspend fun provideY(): Result<Int, BindingError.BindingErrorA> {
-            delay(2)
+            delay(10)
             yStateChange = true
             return Err(BindingError.BindingErrorA)
         }
@@ -103,48 +103,6 @@ class AsyncSuspendableBindingTest {
 
         runBlocking {
             val result = binding<Int, BindingError> {
-                val x = async { provideX().bind() }
-                val y = async { provideY().bind() }
-                val z = async { provideZ().bind() }
-                x.await() + y.await() + z.await()
-            }
-
-            assertTrue(result is Err)
-            assertEquals(
-                expected = BindingError.BindingErrorB,
-                actual = result.error
-            )
-            assertTrue(xStateChange)
-            assertTrue(yStateChange)
-            assertTrue(zStateChange)
-        }
-    }
-
-    @Test
-    fun returnsStateChangedForOnlyTheFirstAsyncBindFailWhenEagerlyCancellingBinding() {
-        var xStateChange = false
-        var yStateChange = false
-        var zStateChange = false
-        suspend fun provideX(): Result<Int, BindingError> {
-            delay(3)
-            xStateChange = true
-            return Ok(1)
-        }
-
-        suspend fun provideY(): Result<Int, BindingError.BindingErrorA> {
-            delay(2)
-            yStateChange = true
-            return Err(BindingError.BindingErrorA)
-        }
-
-        suspend fun provideZ(): Result<Int, BindingError.BindingErrorB> {
-            delay(1)
-            zStateChange = true
-            return Err(BindingError.BindingErrorB)
-        }
-
-        runBlocking {
-            val result = eagerlyCancelBinding<Int, BindingError> {
                 val x = async { provideX().bind() }
                 val y = async { provideY().bind() }
                 val z = async { provideZ().bind() }


### PR DESCRIPTION
After some of the discussion here: https://github.com/michaelbull/kotlin-result/pull/36#discussion_r514505228
I looked into verifying whether all binds will finish executing when ran asynchrounously if a failed binding is encountered and how we should verify the behaviour in our tests. I realised it could be useful to have for compute heavy binding functions ran asynchronously to be able to cancel them eagerly.

Just a suggestion, let me know what you think.