### PR TITLE
Clean up suspend binding implementation

### DIFF
--- a/kotlin-result-coroutines/src/commonMain/kotlin/com/github/michaelbull/result/coroutines/binding/SuspendableBinding.kt
+++ b/kotlin-result-coroutines/src/commonMain/kotlin/com/github/michaelbull/result/coroutines/binding/SuspendableBinding.kt
@@ -3,60 +3,78 @@ package com.github.michaelbull.result.coroutines.binding
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.cancel
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.resume
 
 /**
  * Suspending variant of [binding][com.github.michaelbull.result.binding].
- * Wraps the suspendable block in a new coroutine scope.
- * This scope is cancelled once a failing bind is encountered, allowing deferred child jobs to be eagerly cancelled.
+ * Wraps the suspendable block in an async job, inheriting the parent coroutine context.
+ * This async job is cancelled once a failing bind is encountered, eagerly cancelling all children.
  */
 public suspend inline fun <V, E> binding(crossinline block: suspend SuspendableResultBinding<E>.() -> V): Result<V, E> {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
     }
-    val receiver = SuspendableResultBindingImpl<E>()
-
-    return try {
-        coroutineScope {
-            receiver.coroutineScope = this@coroutineScope
+    lateinit var receiver: SuspendableResultBindingImpl<E>
+    return coroutineScope {
+        val parentJob = async {
+            receiver = SuspendableResultBindingImpl(this.coroutineContext)
             with(receiver) { Ok(block()) }
         }
-    } catch (ex: BindCancellationException) {
-        receiver.internalError
+        try {
+            parentJob.await()
+        } catch (ex: BindCancellationException) {
+            receiver.internalError
+        }
     }
 }
 
 internal object BindCancellationException : CancellationException(null)
 
-public interface SuspendableResultBinding<E> {
+public interface SuspendableResultBinding<E> : CoroutineScope {
     public suspend fun <V> Result<V, E>.bind(): V
 }
 
 @PublishedApi
-internal class SuspendableResultBindingImpl<E> : SuspendableResultBinding<E> {
+internal class SuspendableResultBindingImpl<E>(
+    override val coroutineContext: CoroutineContext
+) : SuspendableResultBinding<E> {
 
     private val mutex = Mutex()
     lateinit var internalError: Err<E>
-    var coroutineScope: CoroutineScope? = null
 
+    /**
+     * Suspends the current coroutine while it attempts to unwrap the result value.
+     * If the result is an error, all [binding] block child jobs are cancelled
+     * and [binding] returns result with error of first failed bind.
+     */
     override suspend fun <V> Result<V, E>.bind(): V {
-        return when (this) {
-            is Ok -> value
-            is Err -> {
-                mutex.withLock {
-                    if (::internalError.isInitialized.not()) {
-                        internalError = this
-                    }
+        return suspendCancellableCoroutine {
+            when (this) {
+                is Ok -> it.resume(value)
+                is Err -> setError(this)
+            }
+        }
+    }
+
+    private fun setError(error: Err<E>) {
+        this.launch {
+            mutex.withLock {
+                if (::internalError.isInitialized.not()) {
+                    internalError = error
+                    this@SuspendableResultBindingImpl.cancel(BindCancellationException)
                 }
-                coroutineScope?.cancel(BindCancellationException)
-                throw BindCancellationException
             }
         }
     }

--- a/kotlin-result-coroutines/src/commonMain/kotlin/com/github/michaelbull/result/coroutines/binding/SuspendableBinding.kt
+++ b/kotlin-result-coroutines/src/commonMain/kotlin/com/github/michaelbull/result/coroutines/binding/SuspendableBinding.kt
@@ -15,8 +15,8 @@ import kotlin.coroutines.CoroutineContext
 
 /**
  * Suspending variant of [binding][com.github.michaelbull.result.binding].
- * Wraps the suspendable block in an async job, inheriting the parent coroutine context.
- * This async job is cancelled once a failing bind is encountered, eagerly cancelling all children.
+ * The suspendable block runs in a new Coroutine Scope inheriting the parent coroutine context.
+ * This new scope is cancelled once a failing bind is encountered, eagerly cancelling all children.
  */
 public suspend inline fun <V, E> binding(crossinline block: suspend SuspendableResultBinding<E>.() -> V): Result<V, E> {
     contract {

--- a/kotlin-result-coroutines/src/jvmTest/kotlin/com/github/michaelbull/result/coroutines/binding/AsyncSuspendableBindingTest.kt
+++ b/kotlin-result-coroutines/src/jvmTest/kotlin/com/github/michaelbull/result/coroutines/binding/AsyncSuspendableBindingTest.kt
@@ -3,9 +3,14 @@ package com.github.michaelbull.result.coroutines.binding
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
-import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.CoroutineName
+import java.util.concurrent.Executors
+import kotlin.coroutines.CoroutineContext
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -53,12 +58,12 @@ class AsyncSuspendableBindingTest {
         }
 
         suspend fun provideY(): Result<Int, BindingError.BindingErrorA> {
-            delay(2)
+            delay(3)
             return Err(BindingError.BindingErrorA)
         }
 
         suspend fun provideZ(): Result<Int, BindingError.BindingErrorB> {
-            delay(1)
+            delay(2)
             return Err(BindingError.BindingErrorB)
         }
 
@@ -82,41 +87,80 @@ class AsyncSuspendableBindingTest {
     fun returnsStateChangedForOnlyTheFirstAsyncBindFailWhenEagerlyCancellingBinding() {
         var xStateChange = false
         var yStateChange = false
-        var zStateChange = false
         suspend fun provideX(): Result<Int, BindingError> {
-            delay(20)
+            delay(2)
             xStateChange = true
-            return Ok(1)
-        }
-
-        suspend fun provideY(): Result<Int, BindingError.BindingErrorA> {
-            delay(10)
-            yStateChange = true
             return Err(BindingError.BindingErrorA)
         }
 
-        suspend fun provideZ(): Result<Int, BindingError.BindingErrorB> {
-            delay(1)
-            zStateChange = true
+        suspend fun provideY(): Result<Int, BindingError.BindingErrorB> {
+            // as this test uses a new thread for each coroutine, we want to set this delay to a high enough number that
+            // there isn't any chance of a jvm run actually completing this suspending function in this thread first
+            // otherwise the assertions might fail.
+            delay(100)
+            yStateChange = true
             return Err(BindingError.BindingErrorB)
         }
 
         runBlocking {
             val result = binding<Int, BindingError> {
-                val x = async { provideX().bind() }
-                val y = async { provideY().bind() }
-                val z = async { provideZ().bind() }
-                x.await() + y.await() + z.await()
+                val x = async(newThread("ThreadA")) { provideX().bind() }
+                val y = async(newThread("ThreadB")) { provideY().bind() }
+                x.await() + y.await()
             }
 
             assertTrue(result is Err)
             assertEquals(
-                expected = BindingError.BindingErrorB,
+                expected = BindingError.BindingErrorA,
                 actual = result.error
             )
-            assertFalse(xStateChange)
+            assertTrue(xStateChange)
             assertFalse(yStateChange)
-            assertTrue(zStateChange)
         }
+    }
+
+    @Test
+    fun returnsStateChangedForOnlyTheFirstLaunchBindFailWhenEagerlyCancellingBinding() {
+        var xStateChange = false
+        var yStateChange = false
+        var zStateChange = false
+        suspend fun provideX(): Result<Int, BindingError> {
+            delay(1)
+            xStateChange = true
+            return Ok(1)
+        }
+
+        suspend fun provideY(): Result<Int, BindingError.BindingErrorA> {
+            delay(20)
+            yStateChange = true
+            return Err(BindingError.BindingErrorA)
+        }
+
+        suspend fun provideZ(): Result<Int, BindingError.BindingErrorB> {
+            delay(100)
+            zStateChange = true
+            return Err(BindingError.BindingErrorB)
+        }
+
+        runBlocking {
+            val result = binding<Unit, BindingError> {
+                launch(newThread("Thread A")) { provideX().bind() }
+                launch(newThread("Thread B")) { provideY().bind() }
+                launch(newThread("Thread C")) { provideZ().bind() }
+            }
+
+            assertTrue(result is Err)
+            assertEquals(
+                expected = BindingError.BindingErrorA,
+                actual = result.error
+            )
+            assertTrue(xStateChange)
+            assertTrue(yStateChange)
+            assertFalse(zStateChange)
+        }
+    }
+
+    private fun newThread(name: String): CoroutineContext {
+        return Executors.newSingleThreadExecutor().asCoroutineDispatcher() + CoroutineName(name)
     }
 }


### PR DESCRIPTION
Also add more real-world test cases and improve its related readme section.

Turns out that with the current implementation, if you `launch` coroutines inside the `binding` block and call `bind` inside one of those `launch`ed child coroutines then when the scope is cancelled these children coroutines aren't getting cancelled (they were basically being launched in the parent scope of `binding` so it had no effect).

Correct solution is to make the lambda block of binding have a receiver of `CoroutineScope`. In this case that meant making `SuspendableResultBinding` implement `CoroutineScope`. 

This way we can launch the binding block inside an async coroutine where its context is used for SuspendableResultBinding (as its now also a `CoroutineScope`), so that when we cancel SuspendableResultBinding, we cancel the async coroutine and all its children.

Also discovered that [`suspendCancellableCoroutine`](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/suspend-cancellable-coroutine.html) makes for a handy way to get around `bind` needing to `throw` in the error case for no reason. Think its a lot cleaner now.