### PR TITLE
Upping Kotlin version to 1.5.10

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,8 +1,8 @@
 object Versions {
     const val dokka = "0.10.1"
-    const val kotlin = "1.4.32"
+    const val kotlin = "1.5.10"
     const val kotlinBenchmark = "0.2.0-dev-20"
-    const val kotlinCoroutines = "1.4.3"
+    const val kotlinCoroutines = "1.5.0"
     const val ktor = "1.5.4"
     const val logback = "1.2.3"
     const val versionsPlugin = "0.38.0"

--- a/kotlin-result-coroutines/src/commonMain/kotlin/com/github/michaelbull/result/coroutines/binding/SuspendableBinding.kt
+++ b/kotlin-result-coroutines/src/commonMain/kotlin/com/github/michaelbull/result/coroutines/binding/SuspendableBinding.kt
@@ -37,7 +37,7 @@ public suspend inline fun <V, E> binding(crossinline block: suspend SuspendableR
     }
 }
 
-internal object BindCancellationException : CancellationException(null)
+internal object BindCancellationException : CancellationException(null as String?)
 
 public interface SuspendableResultBinding<E> : CoroutineScope {
     public suspend fun <V> Result<V, E>.bind(): V


### PR DESCRIPTION
Hello there, first of all wanted to say I'm excited this repo exists! I was thinking of writing exactly this today!

I'm interested in using this library but want to use the latest Kotlin, figured I'd give it a go myself. In addition to upping to the latest Kotlin version I've upped the coroutines version to recommended one (1.5.0) 

One thing that's confused me is upping the Coroutines version caused an overload ambiguity for `CancellationException(null)` in `SuspendableBinding` (line 40).

I've cast the null to a `String?` since I expect that's the behaviour currently, though I'm confused why upping the version caused this since it looks like a `Throwable?` overload has existed for native/js since coroutines 1.1.

All I've done is run the tests and verify they pass, if there's extra checking involved around upping this version I'd be happy to give it a go :)