### PR TITLE
Update kotlinx.benchmark dependencies

### DIFF
--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -37,7 +37,7 @@ kotlin {
             dependencies {
                 implementation(project(":kotlin-result"))
                 implementation(project(":kotlin-result-coroutines"))
-                implementation("org.jetbrains.kotlinx:kotlinx.benchmark.runtime:${Versions.kotlinBenchmark}")
+                implementation("org.jetbrains.kotlinx:kotlinx-benchmark-runtime:${Versions.kotlinBenchmark}")
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.kotlinCoroutines}")
             }
         }

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -2,7 +2,7 @@ description = "Benchmarks for kotlin-result."
 
 plugins {
     kotlin("multiplatform")
-    id("kotlinx.benchmark")
+    id("org.jetbrains.kotlinx.benchmark")
     id("org.jetbrains.kotlin.plugin.allopen")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
     id("com.github.ben-manes.versions") version Versions.versionsPlugin
 
     kotlin("multiplatform") version Versions.kotlin apply false
-    id("kotlinx.benchmark") version Versions.kotlinBenchmark apply false
+    id("org.jetbrains.kotlinx.benchmark") version Versions.kotlinBenchmark apply false
     id("org.jetbrains.dokka") version Versions.dokka apply false
     id("org.jetbrains.kotlin.plugin.allopen") version Versions.kotlin apply false
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,7 +1,7 @@
 object Versions {
     const val dokka = "0.10.1"
     const val kotlin = "1.5.10"
-    const val kotlinBenchmark = "0.2.0-dev-20"
+    const val kotlinBenchmark = "0.3.1"
     const val kotlinCoroutines = "1.5.0"
     const val kotlinCoroutinesTest = "1.5.0"
     const val ktor = "1.5.4"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,7 +9,8 @@ include(
 
 pluginManagement {
     repositories {
-        maven("https://dl.bintray.com/kotlin/kotlinx")
+        // https://github.com/Kotlin/kotlinx-benchmark/issues/42
+        mavenCentral()
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
closes #60 

This PR updated the Gradle dependencies for the kotlinx.bechmarks Gradle plugin to the latest version to be able to build the project