### PR TITLE
Fix gradle warnings

### DIFF
--- a/kotlin-result-coroutines/build.gradle.kts
+++ b/kotlin-result-coroutines/build.gradle.kts
@@ -9,7 +9,7 @@ kotlin {
     sourceSets {
         all {
             languageSettings.apply {
-                useExperimentalAnnotation("kotlin.contracts.ExperimentalContracts")
+                optIn("kotlin.contracts.ExperimentalContracts")
             }
         }
 

--- a/kotlin-result/build.gradle.kts
+++ b/kotlin-result/build.gradle.kts
@@ -17,7 +17,7 @@ kotlin {
     sourceSets {
         all {
             languageSettings.apply {
-                useExperimentalAnnotation("kotlin.contracts.ExperimentalContracts")
+                optIn("kotlin.contracts.ExperimentalContracts")
             }
         }
 


### PR DESCRIPTION
Tiny PR which fixes a couple of warnings caused by use of `useExperimentalAnnotation` which is [deprecated][1].

[1]: https://kotlinlang.org/docs/opt-in-requirements.html
