### PR TITLE
Add getOrThrow

### DIFF
--- a/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Get.kt
+++ b/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Get.kt
@@ -122,6 +122,37 @@ public inline infix fun <V, E> Result<V, E>.getErrorOrElse(transform: (V) -> E):
 }
 
 /**
+ * Returns the [value][Ok.value] if this [Result] is [Ok], otherwise throws the
+ * [error][Err.error].
+ */
+public fun <V, E: Throwable> Result<V, E>.getOrThrow(): V {
+    contract {
+        returns() implies (this@getOrThrow is Ok<V>)
+    }
+
+    return when (this) {
+        is Ok -> value
+        is Err -> throw error
+    }
+}
+
+/**
+ * Returns the [value][Ok.value] if this [Result] is [Ok], otherwise throws the
+ * [transformation][transform] of the [error][Err.error].
+ */
+public inline infix fun <V, E> Result<V, E>.getOrThrow(transform: (E) -> Throwable): V {
+    contract {
+        returns() implies (this@getOrThrow is Ok<V>)
+        callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
+    }
+
+    return when (this) {
+        is Ok -> value
+        is Err -> throw transform(error)
+    }
+}
+
+/**
  * Merges this [Result<V, E>][Result] to [U], returning the [value][Ok.value] if this [Result] is [Ok], otherwise the
  * [error][Err.error].
  *

--- a/kotlin-result/src/commonTest/kotlin/com/github/michaelbull/result/GetTest.kt
+++ b/kotlin-result/src/commonTest/kotlin/com/github/michaelbull/result/GetTest.kt
@@ -2,6 +2,7 @@ package com.github.michaelbull.result
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 
 @Suppress("IMPLICIT_NOTHING_TYPE_ARGUMENT_IN_RETURN_POSITION")
@@ -52,6 +53,44 @@ class GetTest {
                 actual = Err("error").getOr("default")
             )
         }
+    }
+
+    class GetOrThrow {
+        @Test
+        fun returnsValueIfOk() {
+            assertEquals(
+                expected = "hello",
+                actual = Ok("hello").getOrThrow()
+            )
+        }
+
+        @Test
+        fun throwsErrorIfErr() {
+            assertFailsWith<CustomException> {
+                Err(CustomException()).getOrThrow()
+            }
+        }
+
+        class CustomException: Throwable()
+    }
+
+    class GetOrThrowWithTransform {
+        @Test
+        fun returnsValueIfOk() {
+            assertEquals(
+                expected = "hello",
+                actual = Ok("hello").getOrThrow { CustomException("Failed") }
+            )
+        }
+
+        @Test
+        fun throwsTransformedErrorIfErr() {
+            assertFailsWith<CustomException> {
+                Err("error").getOrThrow { error -> CustomException(error) }
+            }
+        }
+
+        class CustomException(message: String): Throwable(message)
     }
 
     class GetErrorOr {


### PR DESCRIPTION
This PR adds getOrThrow functions as described in #68 in addition to associated tests

Two overloads were added, one with a transforming lambda parameter (E -> Throwable) and one without as a specialization for Results with a Throwable error type.

Example usages:

```kt
Ok("hello").getOrThrow() // returns "hello"
Err(IllegalArgumentException()).getOrThrow() // throws the exception inside the Err


Ok("hello").getOrThrow { CustomException("Failed") } // returns "hello"
Err("mishap").getOrThrow { error -> CustomException(error) } // throws the transformed exception
Err(IllegalArgumentException()).getOrThrow { error -> CustomException(error) } // Allows to wrap throwables in more specific domain exceptions

Err("mishap").getOrThrow() // Does not compile since String isn't a subtype of Throwable
```

Closes #68