### PR TITLE
Add iosSimulatorArm64 and macosArm64 targets

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,9 +70,11 @@ subprojects {
                 }
 
                 ios()
+                iosSimulatorArm64()
                 linuxX64()
                 mingwX64()
                 macosX64()
+                macosArm64()
             }
         }
 

--- a/kotlin-result/build.gradle.kts
+++ b/kotlin-result/build.gradle.kts
@@ -61,11 +61,19 @@ kotlin {
             dependsOn(nativeMain)
         }
 
+        val macosArm64Main by getting {
+            dependsOn(nativeMain)
+        }
+
         val iosX64Main by getting {
             dependsOn(nativeMain)
         }
 
         val iosArm64Main by getting {
+            dependsOn(nativeMain)
+        }
+
+        val iosSimulatorArm64Main by getting {
             dependsOn(nativeMain)
         }
     }


### PR DESCRIPTION
This PR adds two missing targets which are required for projects which are built on Mac M1 chips.
Currently any project targeting M1-targets and transitively depending on `kotlin-result` will not compile.

I have tested on M1 Mac that `./gradlew assemble` succesfully compiles and links the project. 
Tests for `macosArm64` are passing too, but `./gradlew check` currently fails on M1 Mac because it tries to run `iosSimulatorArm64Test` and it requires a running XCode & iOS simulator.

Not sure how to best solve this for CI (in case it will be a problem).

Closes #71.