### PR TITLE
Add bind for nullables

### DIFF
--- a/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Binding.kt
+++ b/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Binding.kt
@@ -40,6 +40,14 @@ internal expect object BindException : Exception
 
 public interface ResultBinding<E> {
     public fun <V> Result<V, E>.bind(): V
+    
+    public fun <V> V?.bindOr(error: () -> E): V { 
+        contract {
+            callsInPlace(error, InvocationKind.AT_MOST_ONCE)
+        }
+        
+        return toResultOr(error).bind()
+    }
 }
 
 @PublishedApi


### PR DESCRIPTION
⚠️ Need to add tests

So, we often find ourselves binding nullables with `toResultOr` + `bind`. We wanted to do an extension function, but until we get multiple receivers it's not gonna be possible. So I thought it was worth creating a default function to `ResultBinding`