### PR TITLE
Add support for additional multiplatform targets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,10 +38,10 @@ jobs:
         with:
           java-version: 1.8
 
-      - run: ./gradlew $(./gradlew tasks | grep "Test " | grep "linux" | cut -d ' ' -f 1)
+      - run: ./gradlew linuxX64Test
         if: matrix.os == 'ubuntu-latest'
 
-      - run: ./gradlew $(./gradlew tasks | grep "Test " | grep "mingw" | cut -d ' ' -f 1)
+      - run: ./gradlew mingwX64Test
         if: matrix.os == 'windows-latest'
 
       - run: ./gradlew build
@@ -91,11 +91,47 @@ jobs:
         with:
           java-version: 1.8
 
-      - run: ./gradlew $(./gradlew tasks | grep "PublicationToMavenRepository" | grep -e "publishAndroid" -e "publishJs" -e "publishJvm" -e "publishKotlinMultiplatform" -e "publishLinux" -e "publishWasm" | cut -d ' ' -f 1)
-        if: matrix.os == 'ubuntu-latest'
+      # ./gradlew tasks | grep "PublicationToMavenRepository" | grep -e "publishAndroid" -e "publishJs" -e "publishJvm" -e "publishKotlinMultiplatform" -e "publishLinux" -e "publishWasm" | cut -d ' ' -f 1
+      - if: matrix.os == 'ubuntu-latest'
+        run: >
+          ./gradlew
+          publishAndroidNativeArm32PublicationToMavenRepository
+          publishAndroidNativeArm64PublicationToMavenRepository
+          publishAndroidNativeX64PublicationToMavenRepository
+          publishAndroidNativeX86PublicationToMavenRepository
+          publishJsPublicationToMavenRepository
+          publishJvmPublicationToMavenRepository
+          publishKotlinMultiplatformPublicationToMavenRepository
+          publishLinuxArm32HfpPublicationToMavenRepository
+          publishLinuxArm64PublicationToMavenRepository
+          publishLinuxMips32PublicationToMavenRepository
+          publishLinuxMipsel32PublicationToMavenRepository
+          publishLinuxX64PublicationToMavenRepository
+          publishWasm32PublicationToMavenRepository
 
-      - run: ./gradlew $(./gradlew tasks | grep "PublicationToMavenRepository" | grep "publishMingw" | cut -d ' ' -f 1)
-        if: matrix.os == 'windows-latest'
+      # ./gradlew tasks | grep "PublicationToMavenRepository" | grep "publishMingw" | cut -d ' ' -f 1
+      - if: matrix.os == 'windows-latest'
+        run: >
+          ./gradlew
+          publishMingwX64PublicationToMavenRepository
+          publishMingwX86PublicationToMavenRepository
 
-      - run: ./gradlew $(./gradlew tasks | grep "PublicationToMavenRepository" | grep -e "publishIos" -e "publishMacos" -e "publishTvos" -e "publishWatchos" | cut -d ' ' -f 1)
-        if: matrix.os == 'macos-11'
+      # ./gradlew tasks | grep "PublicationToMavenRepository" | grep -e "publishIos" -e "publishMacos" -e "publishTvos" -e "publishWatchos" | cut -d ' ' -f 1
+      - if: matrix.os == 'macos-11'
+        run: >
+          ./gradlew
+          publishIosArm32PublicationToMavenRepository
+          publishIosArm64PublicationToMavenRepository
+          publishIosSimulatorArm64PublicationToMavenRepository
+          publishIosX64PublicationToMavenRepository
+          publishMacosArm64PublicationToMavenRepository
+          publishMacosX64PublicationToMavenRepository
+          publishTvosArm64PublicationToMavenRepository
+          publishTvosSimulatorArm64PublicationToMavenRepository
+          publishTvosX64PublicationToMavenRepository
+          publishWatchosArm32PublicationToMavenRepository
+          publishWatchosArm64PublicationToMavenRepository
+          publishWatchosSimulatorArm64PublicationToMavenRepository
+          publishWatchosX64PublicationToMavenRepository
+          publishWatchosX86PublicationToMavenRepository
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,10 +38,10 @@ jobs:
         with:
           java-version: 1.8
 
-      - run: ./gradlew linuxX64Test
+      - run: ./gradlew $(./gradlew tasks | grep "Test " | grep "linux" | cut -d ' ' -f 1)
         if: matrix.os == 'ubuntu-latest'
 
-      - run: ./gradlew mingwX64Test
+      - run: ./gradlew $(./gradlew tasks | grep "Test " | grep "mingw" | cut -d ' ' -f 1)
         if: matrix.os == 'windows-latest'
 
       - run: ./gradlew build
@@ -91,11 +91,11 @@ jobs:
         with:
           java-version: 1.8
 
-      - run: ./gradlew publishLinuxX64PublicationToMavenRepository
+      - run: ./gradlew $(./gradlew tasks | grep "PublicationToMavenRepository" | grep -e "publishAndroid" -e "publishJs" -e "publishJvm" -e "publishKotlinMultiplatform" -e "publishLinux" -e "publishWasm" | cut -d ' ' -f 1)
         if: matrix.os == 'ubuntu-latest'
 
-      - run: ./gradlew publishMingwX64PublicationToMavenRepository
+      - run: ./gradlew $(./gradlew tasks | grep "PublicationToMavenRepository" | grep "publishMingw" | cut -d ' ' -f 1)
         if: matrix.os == 'windows-latest'
 
-      - run: ./gradlew publish
+      - run: ./gradlew $(./gradlew tasks | grep "PublicationToMavenRepository" | grep -e "publishIos" -e "publishMacos" -e "publishTvos" -e "publishWatchos" | cut -d ' ' -f 1)
         if: matrix.os == 'macos-11'

--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ dependencies {
 }
 ```
 
+**DISCLAIMER:** Supported platforms for the `kotlin-result-coroutines` dependency are
+limited to that which coroutines currently supports.
+
 The coroutine implementation of `binding` has been designed so that the first
 call to `bind()` that fails will cancel all child coroutines within the current
 coroutine scope.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,8 @@
 [![License](https://img.shields.io/github/license/michaelbull/kotlin-result.svg)](https://github.com/michaelbull/kotlin-result/blob/master/LICENSE)
 
 ![badge][badge-android]
-![badge][badge-android-native]
 ![badge][badge-jvm]
 ![badge][badge-js]
-![badge][badge-js-ir]
 ![badge][badge-nodejs]
 ![badge][badge-linux]
 ![badge][badge-windows]
@@ -17,6 +15,8 @@
 ![badge][badge-mac]
 ![badge][badge-tvos]
 ![badge][badge-watchos]
+![badge][badge-js-ir]
+![badge][badge-android-native]
 ![badge][badge-apple-silicon]
 
 [`Result<V, E>`][result] is a monad for modelling success ([`Ok`][result-ok]) or
@@ -315,7 +315,7 @@ This project is available under the terms of the ISC license. See the
 [either-syntax]: https://arrow-kt.io/docs/0.10/apidocs/arrow-core-data/arrow.core/-either/#syntax
 
 [badge-android]: http://img.shields.io/badge/-android-6EDB8D.svg?style=flat
-[badge-android-native]: http://img.shields.io/badge/-android--native-6EDB8D.svg?style=flat
+[badge-android-native]: http://img.shields.io/badge/support-[AndroidNative]-6EDB8D.svg?style=flat
 [badge-jvm]: http://img.shields.io/badge/-jvm-DB413D.svg?style=flat
 [badge-js]: http://img.shields.io/badge/-js-F8DB5D.svg?style=flat
 [badge-js-ir]: https://img.shields.io/badge/support-[IR]-AAC4E0.svg?style=flat

--- a/README.md
+++ b/README.md
@@ -4,14 +4,19 @@
 [![CI Status](https://github.com/michaelbull/kotlin-result/workflows/ci/badge.svg)](https://github.com/michaelbull/kotlin-result/actions?query=workflow%3Aci)
 [![License](https://img.shields.io/github/license/michaelbull/kotlin-result.svg)](https://github.com/michaelbull/kotlin-result/blob/master/LICENSE)
 
+![badge][badge-android]
+![badge][badge-android-native]
 ![badge][badge-jvm]
 ![badge][badge-js]
+![badge][badge-js-ir]
 ![badge][badge-nodejs]
-![badge][badge-ios]
 ![badge][badge-linux]
 ![badge][badge-windows]
+![badge][badge-wasm]
+![badge][badge-ios]
 ![badge][badge-mac]
-![badge][badge-js-ir]
+![badge][badge-tvos]
+![badge][badge-watchos]
 ![badge][badge-apple-silicon]
 
 [`Result<V, E>`][result] is a monad for modelling success ([`Ok`][result-ok]) or
@@ -310,6 +315,7 @@ This project is available under the terms of the ISC license. See the
 [either-syntax]: https://arrow-kt.io/docs/0.10/apidocs/arrow-core-data/arrow.core/-either/#syntax
 
 [badge-android]: http://img.shields.io/badge/-android-6EDB8D.svg?style=flat
+[badge-android-native]: http://img.shields.io/badge/-android--native-6EDB8D.svg?style=flat
 [badge-jvm]: http://img.shields.io/badge/-jvm-DB413D.svg?style=flat
 [badge-js]: http://img.shields.io/badge/-js-F8DB5D.svg?style=flat
 [badge-js-ir]: https://img.shields.io/badge/support-[IR]-AAC4E0.svg?style=flat

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,12 +75,23 @@ subprojects {
                     nodejs()
                 }
 
-                ios()
-                iosSimulatorArm64()
                 linuxX64()
+
                 mingwX64()
+
                 macosX64()
                 macosArm64()
+
+                ios()
+                iosArm32()
+                iosSimulatorArm64()
+
+                tvos()
+                tvosSimulatorArm64()
+
+                watchos()
+                watchosX86()
+                watchosSimulatorArm64()
             }
         }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -211,6 +211,11 @@ subprojects {
                             name.set("Berik Visschers")
                             url.set("https://visschers.nu/")
                         }
+
+                        contributor {
+                            name.set("Matthew Nelson")
+                            url.set("https://matthewnelson.io/")
+                        }
                     }
 
                     scm {

--- a/kotlin-result/build.gradle.kts
+++ b/kotlin-result/build.gradle.kts
@@ -14,6 +14,21 @@ kotlin {
         }
     }
 
+    // Additional targets not currently supported by coroutines
+    androidNativeArm32()
+    androidNativeArm64()
+    androidNativeX64()
+    androidNativeX86()
+
+    linuxArm32Hfp()
+    linuxArm64()
+    linuxMips32()
+    linuxMipsel32()
+
+    mingwX86()
+
+    wasm32()
+
     sourceSets {
         all {
             languageSettings.apply {
@@ -49,31 +64,150 @@ kotlin {
             dependsOn(commonMain)
         }
 
-        val linuxX64Main by getting {
+        val androidNativeMain by creating {
             dependsOn(nativeMain)
         }
 
-        val mingwX64Main by getting {
+        val mingwMain by creating {
             dependsOn(nativeMain)
+        }
+
+        val unixMain by creating {
+            dependsOn(nativeMain)
+        }
+
+        val linuxMain by creating {
+            dependsOn(unixMain)
+        }
+
+        val darwinMain by creating {
+            dependsOn(unixMain)
+        }
+
+        val macosMain by creating {
+            dependsOn(darwinMain)
+        }
+
+        val iosMain by getting {
+            dependsOn(darwinMain)
+        }
+
+        val tvosMain by getting {
+            dependsOn(darwinMain)
+        }
+
+        val watchosMain by getting {
+            dependsOn(darwinMain)
+        }
+
+        // Android Native
+        val androidNativeArm32Main by getting {
+            dependsOn(androidNativeMain)
+        }
+
+        val androidNativeArm64Main by getting {
+            dependsOn(androidNativeMain)
+        }
+
+        val androidNativeX64Main by getting {
+            dependsOn(androidNativeMain)
+        }
+
+        val androidNativeX86Main by getting {
+            dependsOn(androidNativeMain)
+        }
+
+        // Linux
+        val linuxArm32HfpMain by getting {
+            dependsOn(linuxMain)
+        }
+
+        val linuxArm64Main by getting {
+            dependsOn(linuxMain)
+        }
+
+        val linuxMips32Main by getting {
+            dependsOn(linuxMain)
+        }
+
+        val linuxMipsel32Main by getting {
+            dependsOn(linuxMain)
+        }
+
+        val linuxX64Main by getting {
+            dependsOn(linuxMain)
+        }
+
+        // Mingw
+        val mingwX64Main by getting {
+            dependsOn(mingwMain)
+        }
+
+        val mingwX86Main by getting {
+            dependsOn(mingwMain)
+        }
+
+        // Darwin [ macOS ]
+        val macosArm64Main by getting {
+            dependsOn(macosMain)
         }
 
         val macosX64Main by getting {
-            dependsOn(nativeMain)
+            dependsOn(macosMain)
         }
 
-        val macosArm64Main by getting {
-            dependsOn(nativeMain)
-        }
-
-        val iosX64Main by getting {
-            dependsOn(nativeMain)
+        // Darwin [ iOS ]
+        val iosArm32Main by getting {
+            dependsOn(iosMain)
         }
 
         val iosArm64Main by getting {
-            dependsOn(nativeMain)
+            dependsOn(iosMain)
+        }
+
+        val iosX64Main by getting {
+            dependsOn(iosMain)
         }
 
         val iosSimulatorArm64Main by getting {
+            dependsOn(iosMain)
+        }
+
+        // Darwin [ tvOS ]
+        val tvosArm64Main by getting {
+            dependsOn(tvosMain)
+        }
+
+        val tvosX64Main by getting {
+            dependsOn(tvosMain)
+        }
+
+        val tvosSimulatorArm64Main by getting {
+            dependsOn(tvosMain)
+        }
+
+        // Darwin [ watchOS ]
+        val watchosArm32Main by getting {
+            dependsOn(watchosMain)
+        }
+
+        val watchosArm64Main by getting {
+            dependsOn(watchosMain)
+        }
+
+        val watchosX64Main by getting {
+            dependsOn(watchosMain)
+        }
+
+        val watchosX86Main by getting {
+            dependsOn(watchosMain)
+        }
+
+        val watchosSimulatorArm64Main by getting {
+            dependsOn(watchosMain)
+        }
+
+        val wasm32Main by getting {
             dependsOn(nativeMain)
         }
     }


### PR DESCRIPTION
This PR includes the following modifications:

- Adds support for additional multiplatform targets to modules `kotlin-result` and `kotlin-result-coroutines`:
     - `iosArm32`
     - `tvosArm64`
     - `tvosX64`
     - `tvosSimulatorArm64`
     - `watchosArm32`
     - `watchosArm64`
     - `watchosX64`
     - `watchosX86`
     - `watchosSimulatorArm64`
- Adds support for additional multiplatform targets to module `kotlin-result` (in addition to above):
     - `androidNativeArm32`
     - `androidNativeArm64`
     - `androidNativeX64`
     - `androidNativeX86`
     - `linuxArm32Hfp`
     - `linuxArm64`
     - `linuxMips32`
     - `linuxMipsel32`
     - `mingwX86`
     - `wasm32`
- Updates GitHub Actions test/build & publishing for all targets
- Updates the `README` with new supported platforms

Closes #77 