### PR TITLE
Use `api` in lieu of `implementation`

### DIFF
--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -34,7 +34,6 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(project(":kotlin-result"))
                 implementation(project(":kotlin-result-coroutines"))
                 implementation("org.jetbrains.kotlinx:kotlinx-benchmark-runtime:${Versions.kotlinBenchmark}")
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.kotlinCoroutines}")

--- a/kotlin-result-coroutines/build.gradle.kts
+++ b/kotlin-result-coroutines/build.gradle.kts
@@ -16,7 +16,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.kotlinCoroutines}")
-                implementation(project(":kotlin-result"))
+                api(project(":kotlin-result"))
             }
         }
 


### PR DESCRIPTION
This PR modifies the dependency graph such that the `kotlin-result` module is automatically imported for library consumers who are depending on `kotlin-result-coroutines`.