### PR TITLE
Add tryRecoverIf and tryRecoverUnless functions

### DIFF
--- a/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/And.kt
+++ b/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/And.kt
@@ -43,6 +43,23 @@ public inline infix fun <V, E, U> Result<V, E>.andThen(transform: (V) -> Result<
 }
 
 /**
+ * Returns the [transformation][transform] of the [error][Err.error] if this [Result] is [Err],
+ * otherwise this [Result].
+ */
+public inline fun <V, E> Result<V, E>.andThenRecover(
+    transform: (E) -> Result<V, E>
+): Result<V, E> {
+    contract {
+        callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
+    }
+
+    return when (this) {
+        is Ok -> this
+        is Err -> transform(error)
+    }
+}
+
+/**
  * Returns the [transformation][transform] of the [error][Err.error] if this [Result] is [Err] and
  * satisfies the given [predicate], otherwise this [Result].
  */

--- a/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/And.kt
+++ b/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/And.kt
@@ -41,3 +41,49 @@ public inline infix fun <V, E, U> Result<V, E>.andThen(transform: (V) -> Result<
         is Err -> this
     }
 }
+
+/**
+ * Returns the [transformation][transform] of the [error][Err.error] if this [Result] is [Err] and
+ * satisfies the given [predicate], otherwise this [Result].
+ */
+public inline fun <V, E> Result<V, E>.andThenRecoverIf(
+    predicate: (E) -> Boolean,
+    transform: (E) -> Result<V, E>
+): Result<V, E> {
+    contract {
+        callsInPlace(predicate, InvocationKind.AT_MOST_ONCE)
+        callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
+    }
+
+    return when (this) {
+        is Ok -> this
+        is Err -> if (predicate(error)) {
+            transform(error)
+        } else {
+            this
+        }
+    }
+}
+
+/**
+ * Returns the [transformation][transform] of the [error][Err.error] if this [Result] is [Err]
+ * and _does not_ satisfy the given [predicate], otherwise this [Result].
+ */
+public inline fun <V, E> Result<V, E>.andThenRecoverUnless(
+    predicate: (E) -> Boolean,
+    transform: (E) -> Result<V, E>
+): Result<V, E> {
+    contract {
+        callsInPlace(predicate, InvocationKind.AT_MOST_ONCE)
+        callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
+    }
+
+    return when (this) {
+        is Ok -> this
+        is Err -> if (!predicate(error)) {
+            transform(error)
+        } else {
+            this
+        }
+    }
+}

--- a/kotlin-result/src/commonTest/kotlin/com/github/michaelbull/result/AndTest.kt
+++ b/kotlin-result/src/commonTest/kotlin/com/github/michaelbull/result/AndTest.kt
@@ -42,4 +42,104 @@ class AndTest {
             )
         }
     }
+
+    class AndThenRecoverIf {
+        @Test
+        fun returnsValueIfOk() {
+            fun predicate(int: Int): Boolean {
+                return int == 4000
+            }
+
+            assertEquals(
+                expected = Ok(3000),
+                actual = Ok(3000).andThenRecoverIf(::predicate) { Ok(2000) }
+            )
+        }
+
+        @Test
+        fun returnsTransformedErrorAsOkIfErrAndPredicateMatch() {
+            fun predicate(int: Int): Boolean {
+                return int == 4000
+            }
+
+            assertEquals(
+                expected = Ok(2000),
+                actual = Err(4000).andThenRecoverIf(::predicate) { Ok(2000) }
+            )
+        }
+
+        @Test
+        fun returnsTransformedErrorAsErrorIfErrAndPredicateMatch() {
+            fun predicate(int: Int): Boolean {
+                return int == 4000
+            }
+
+            assertEquals(
+                expected = Err(2000),
+                actual = Err(4000).andThenRecoverIf(::predicate) { Err(2000) }
+            )
+        }
+
+        @Test
+        fun doesNotReturnTransformationResultIfErrAndPredicateDoesNotMatch() {
+            fun predicate(int: Int): Boolean {
+                return int == 3000
+            }
+
+            assertEquals(
+                expected = Err(4000),
+                actual = Err(4000).andThenRecoverIf(::predicate) { Ok(2000) }
+            )
+        }
+    }
+
+    class AndThenRecoverUnless {
+        @Test
+        fun returnsValueIfOk() {
+            fun predicate(int: Int): Boolean {
+                return int == 4000
+            }
+
+            assertEquals(
+                expected = Ok(3000),
+                actual = Ok(3000).andThenRecoverUnless(::predicate) { Ok(2000) }
+            )
+        }
+
+        @Test
+        fun returnsTransformedErrorAsOkIfErrAndPredicateDoesNotMatch() {
+            fun predicate(int: Int): Boolean {
+                return int == 3000
+            }
+
+            assertEquals(
+                expected = Ok(2000),
+                actual = Err(4000).andThenRecoverUnless(::predicate) { Ok(2000) }
+            )
+        }
+
+        @Test
+        fun returnsTransformedErrorAsErrorIfErrAndPredicateDoesNotMatch() {
+            fun predicate(int: Int): Boolean {
+                return int == 3000
+            }
+
+            assertEquals(
+                expected = Err(2000),
+                actual = Err(4000).andThenRecoverUnless(::predicate) { Err(2000) }
+            )
+        }
+
+        @Test
+        fun doesNotReturnTransformationResultIfErrAndPredicateMatches() {
+            fun predicate(int: Int): Boolean {
+                return int == 4000
+            }
+
+            assertEquals(
+                expected = Err(4000),
+                actual = Err(4000).andThenRecoverUnless(::predicate) { Ok(2000) }
+            )
+        }
+    }
 }

--- a/kotlin-result/src/commonTest/kotlin/com/github/michaelbull/result/AndTest.kt
+++ b/kotlin-result/src/commonTest/kotlin/com/github/michaelbull/result/AndTest.kt
@@ -43,6 +43,24 @@ class AndTest {
         }
     }
 
+    class AndThenRecover {
+        @Test
+        fun returnsValueIfOk() {
+            assertEquals(
+                expected = 5,
+                actual = Ok(5).andThenRecover { Ok(7) }.get()
+            )
+        }
+
+        @Test
+        fun returnsTransformValueIfErr() {
+            assertEquals(
+                expected = 20,
+                actual = Err(AndError).andThenRecover { Ok(20) }.get()
+            )
+        }
+    }
+
     class AndThenRecoverIf {
         @Test
         fun returnsValueIfOk() {


### PR DESCRIPTION
Sometimes there is a need to recover certain errors and this recovery may produce an error on its own. Existing recoverIf function doesn't fit this case because the result of transformation is wrapped in Ok. Added tryRecoverIf and tryRecoverUnless for the described case.