### PR TITLE
Use List as return type for zipOrAccumulate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,25 +102,20 @@ jobs:
           publishJsPublicationToMavenRepository
           publishJvmPublicationToMavenRepository
           publishKotlinMultiplatformPublicationToMavenRepository
-          publishLinuxArm32HfpPublicationToMavenRepository
           publishLinuxArm64PublicationToMavenRepository
-          publishLinuxMips32PublicationToMavenRepository
-          publishLinuxMipsel32PublicationToMavenRepository
           publishLinuxX64PublicationToMavenRepository
-          publishWasm32PublicationToMavenRepository
+          publishWasmJsPublicationToMavenRepository
 
       # ./gradlew tasks | grep "PublicationToMavenRepository" | grep "publishMingw" | cut -d ' ' -f 1
       - if: matrix.os == 'windows-latest'
         run: >
           ./gradlew
           publishMingwX64PublicationToMavenRepository
-          publishMingwX86PublicationToMavenRepository
 
       # ./gradlew tasks | grep "PublicationToMavenRepository" | grep -e "publishIos" -e "publishMacos" -e "publishTvos" -e "publishWatchos" | cut -d ' ' -f 1
       - if: matrix.os == 'macos-11'
         run: >
           ./gradlew
-          publishIosArm32PublicationToMavenRepository
           publishIosArm64PublicationToMavenRepository
           publishIosSimulatorArm64PublicationToMavenRepository
           publishIosX64PublicationToMavenRepository
@@ -133,5 +128,4 @@ jobs:
           publishWatchosArm64PublicationToMavenRepository
           publishWatchosSimulatorArm64PublicationToMavenRepository
           publishWatchosX64PublicationToMavenRepository
-          publishWatchosX86PublicationToMavenRepository
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,15 +84,13 @@ subprojects {
                 macosX64()
                 macosArm64()
 
-                ios()
-                iosArm32()
+                iosArm64()
                 iosSimulatorArm64()
 
-                tvos()
+                tvosArm64()
                 tvosSimulatorArm64()
 
-                watchos()
-                watchosX86()
+                watchosArm64()
                 watchosSimulatorArm64()
             }
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
-dokka = "1.8.10"
-kotlin = "1.8.10"
-kotlin-benchmark = "0.4.7"
-kotlin-coroutines = "1.6.4"
-ktor = "2.2.4"
-logback = "1.4.6"
-versions-plugin = "0.46.0"
+dokka = "1.9.10"
+kotlin = "1.9.21"
+kotlin-benchmark = "0.4.9"
+kotlin-coroutines = "1.7.3"
+ktor = "2.3.6"
+logback = "1.4.12"
+versions-plugin = "0.50.0"
 
 [libraries]
 logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }

--- a/kotlin-result-coroutines/build.gradle.kts
+++ b/kotlin-result-coroutines/build.gradle.kts
@@ -13,14 +13,14 @@ kotlin {
             }
         }
 
-        val commonMain by getting {
+        commonMain {
             dependencies {
                 implementation(libs.kotlin.coroutines.core)
                 api(project(":kotlin-result"))
             }
         }
 
-        val commonTest by getting {
+        commonTest {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
@@ -28,14 +28,14 @@ kotlin {
             }
         }
 
-        val jvmTest by getting {
+        jvmTest {
             dependencies {
                 implementation(kotlin("test-junit"))
                 implementation(kotlin("test"))
             }
         }
 
-        val jsTest by getting {
+        jsTest {
             dependencies {
                 implementation(kotlin("test-js"))
             }

--- a/kotlin-result/build.gradle.kts
+++ b/kotlin-result/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
+import org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask
+
 description = "A Result monad for modelling success or failure operations."
 
 plugins {
@@ -14,14 +17,13 @@ kotlin {
     androidNativeX64()
     androidNativeX86()
 
-    linuxArm32Hfp()
     linuxArm64()
-    linuxMips32()
-    linuxMipsel32()
 
-    mingwX86()
-
-    wasm32()
+    @OptIn(org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl::class)
+    wasmJs {
+        binaries.executable()
+        nodejs()
+    }
 
     sourceSets {
         all {
@@ -30,179 +32,22 @@ kotlin {
             }
         }
 
-        val commonMain by getting {
-
-        }
-
-        val commonTest by getting {
+        commonTest {
             dependencies {
-                implementation(kotlin("test-common"))
-                implementation(kotlin("test-annotations-common"))
-            }
-        }
-
-        val jvmTest by getting {
-            dependencies {
-                implementation(kotlin("test-junit"))
                 implementation(kotlin("test"))
             }
         }
 
-        val jsTest by getting {
+        jvmTest {
             dependencies {
-                implementation(kotlin("test-js"))
+                implementation(kotlin("test-junit"))
             }
         }
 
-        val nativeMain by creating {
-            dependsOn(commonMain)
-        }
-
-        val androidNativeMain by creating {
-            dependsOn(nativeMain)
-        }
-
-        val mingwMain by creating {
-            dependsOn(nativeMain)
-        }
-
-        val unixMain by creating {
-            dependsOn(nativeMain)
-        }
-
-        val linuxMain by creating {
-            dependsOn(unixMain)
-        }
-
-        val darwinMain by creating {
-            dependsOn(unixMain)
-        }
-
-        val macosMain by creating {
-            dependsOn(darwinMain)
-        }
-
-        val iosMain by getting {
-            dependsOn(darwinMain)
-        }
-
-        val tvosMain by getting {
-            dependsOn(darwinMain)
-        }
-
-        val watchosMain by getting {
-            dependsOn(darwinMain)
-        }
-
-        // Android Native
-        val androidNativeArm32Main by getting {
-            dependsOn(androidNativeMain)
-        }
-
-        val androidNativeArm64Main by getting {
-            dependsOn(androidNativeMain)
-        }
-
-        val androidNativeX64Main by getting {
-            dependsOn(androidNativeMain)
-        }
-
-        val androidNativeX86Main by getting {
-            dependsOn(androidNativeMain)
-        }
-
-        // Linux
-        val linuxArm32HfpMain by getting {
-            dependsOn(linuxMain)
-        }
-
-        val linuxArm64Main by getting {
-            dependsOn(linuxMain)
-        }
-
-        val linuxMips32Main by getting {
-            dependsOn(linuxMain)
-        }
-
-        val linuxMipsel32Main by getting {
-            dependsOn(linuxMain)
-        }
-
-        val linuxX64Main by getting {
-            dependsOn(linuxMain)
-        }
-
-        // Mingw
-        val mingwX64Main by getting {
-            dependsOn(mingwMain)
-        }
-
-        val mingwX86Main by getting {
-            dependsOn(mingwMain)
-        }
-
-        // Darwin [ macOS ]
-        val macosArm64Main by getting {
-            dependsOn(macosMain)
-        }
-
-        val macosX64Main by getting {
-            dependsOn(macosMain)
-        }
-
-        // Darwin [ iOS ]
-        val iosArm32Main by getting {
-            dependsOn(iosMain)
-        }
-
-        val iosArm64Main by getting {
-            dependsOn(iosMain)
-        }
-
-        val iosX64Main by getting {
-            dependsOn(iosMain)
-        }
-
-        val iosSimulatorArm64Main by getting {
-            dependsOn(iosMain)
-        }
-
-        // Darwin [ tvOS ]
-        val tvosArm64Main by getting {
-            dependsOn(tvosMain)
-        }
-
-        val tvosX64Main by getting {
-            dependsOn(tvosMain)
-        }
-
-        val tvosSimulatorArm64Main by getting {
-            dependsOn(tvosMain)
-        }
-
-        // Darwin [ watchOS ]
-        val watchosArm32Main by getting {
-            dependsOn(watchosMain)
-        }
-
-        val watchosArm64Main by getting {
-            dependsOn(watchosMain)
-        }
-
-        val watchosX64Main by getting {
-            dependsOn(watchosMain)
-        }
-
-        val watchosX86Main by getting {
-            dependsOn(watchosMain)
-        }
-
-        val watchosSimulatorArm64Main by getting {
-            dependsOn(watchosMain)
-        }
-
-        val wasm32Main by getting {
-            dependsOn(nativeMain)
+        jsTest {
+            dependencies {
+                implementation(kotlin("test-js"))
+            }
         }
     }
 }
@@ -213,4 +58,14 @@ publishing {
             description.set(project.description)
         }
     }
+}
+
+/* https://youtrack.jetbrains.com/issue/KT-63014/Running-tests-with-wasmJs-in-1.9.20-requires-Chrome-Canary#focus=Comments-27-8321383.0-0 */
+rootProject.the<NodeJsRootExtension>().apply {
+    nodeVersion = "21.0.0-v8-canary202309143a48826a08"
+    nodeDownloadBaseUrl = "https://nodejs.org/download/v8-canary"
+}
+
+rootProject.tasks.withType<KotlinNpmInstallTask>().configureEach {
+    args.add("--ignore-engines")
 }

--- a/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Zip.kt
+++ b/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Zip.kt
@@ -217,7 +217,7 @@ public inline fun <T1, T2, T3, T4, E, V> zipOrAccumulate(
     producer3: () -> Result<T3, E>,
     producer4: () -> Result<T4, E>,
     transform: (T1, T2, T3, T4) -> V,
-): Result<V, Collection<E>> {
+): Result<V, List<E>> {
     contract {
         callsInPlace(producer1, InvocationKind.EXACTLY_ONCE)
         callsInPlace(producer2, InvocationKind.EXACTLY_ONCE)
@@ -268,7 +268,7 @@ public inline fun <T1, T2, T3, T4, T5, E, V> zipOrAccumulate(
     producer4: () -> Result<T4, E>,
     producer5: () -> Result<T5, E>,
     transform: (T1, T2, T3, T4, T5) -> V,
-): Result<V, Collection<E>> {
+): Result<V, List<E>> {
     contract {
         callsInPlace(producer1, InvocationKind.EXACTLY_ONCE)
         callsInPlace(producer2, InvocationKind.EXACTLY_ONCE)

--- a/kotlin-result/src/wasmJsMain/kotlin/com/github/michaelbull/result/BindException.kt
+++ b/kotlin-result/src/wasmJsMain/kotlin/com/github/michaelbull/result/BindException.kt
@@ -1,0 +1,3 @@
+package com.github.michaelbull.result
+
+internal actual object BindException : Exception()


### PR DESCRIPTION
We have unified the return type of some zipOrAccumulate functions from Result<V, Collection<E>> to Result<V, List<E>>. This was probably a mistake, but if it was intentional, please reject this.

Returning Result<V, Collection<E>> is inconvenient because, even though the content is List, it requires casting or similar operations on the caller's side.