### PR TITLE
Use List as return type for zipOrAccumulate

### DIFF
--- a/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Zip.kt
+++ b/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Zip.kt
@@ -217,7 +217,7 @@ public inline fun <T1, T2, T3, T4, E, V> zipOrAccumulate(
     producer3: () -> Result<T3, E>,
     producer4: () -> Result<T4, E>,
     transform: (T1, T2, T3, T4) -> V,
-): Result<V, Collection<E>> {
+): Result<V, List<E>> {
     contract {
         callsInPlace(producer1, InvocationKind.EXACTLY_ONCE)
         callsInPlace(producer2, InvocationKind.EXACTLY_ONCE)
@@ -268,7 +268,7 @@ public inline fun <T1, T2, T3, T4, T5, E, V> zipOrAccumulate(
     producer4: () -> Result<T4, E>,
     producer5: () -> Result<T5, E>,
     transform: (T1, T2, T3, T4, T5) -> V,
-): Result<V, Collection<E>> {
+): Result<V, List<E>> {
     contract {
         callsInPlace(producer1, InvocationKind.EXACTLY_ONCE)
         callsInPlace(producer2, InvocationKind.EXACTLY_ONCE)


### PR DESCRIPTION
I unified the return type of some zipOrAccumulate functions from Result<V, Collection> to Result<V, List>. This was probably a mistake, but if it was intentional, please reject this.

Returning Result<V, Collection> is inconvenient because, even though the content is List, it requires casting or similar operations on the caller's side.