### PR TITLE
Fixing Indeterminate Behavior Caused by `InvocationKind.EXACTLY_ONCE`

### DIFF
--- a/kotlin-result-coroutines/src/commonMain/kotlin/com/github/michaelbull/result/coroutines/CoroutineBinding.kt
+++ b/kotlin-result-coroutines/src/commonMain/kotlin/com/github/michaelbull/result/coroutines/CoroutineBinding.kt
@@ -41,7 +41,7 @@ import kotlin.contracts.contract
  */
 public suspend inline fun <V, E> coroutineBinding(crossinline block: suspend CoroutineBindingScope<E>.() -> V): Result<V, E> {
     contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        callsInPlace(block, InvocationKind.AT_MOST_ONCE)
     }
 
     lateinit var receiver: CoroutineBindingScopeImpl<E>

--- a/kotlin-result-coroutines/src/commonMain/kotlin/com/github/michaelbull/result/coroutines/RunSuspendCatching.kt
+++ b/kotlin-result-coroutines/src/commonMain/kotlin/com/github/michaelbull/result/coroutines/RunSuspendCatching.kt
@@ -16,7 +16,7 @@ import kotlin.contracts.contract
  */
 public inline fun <V> runSuspendCatching(block: () -> V): Result<V, Throwable> {
     contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        callsInPlace(block, InvocationKind.AT_MOST_ONCE)
     }
 
     return runCatching(block).throwIf {
@@ -33,7 +33,7 @@ public inline fun <V> runSuspendCatching(block: () -> V): Result<V, Throwable> {
  */
 public inline infix fun <T, V> T.runSuspendCatching(block: T.() -> V): Result<V, Throwable> {
     contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        callsInPlace(block, InvocationKind.AT_MOST_ONCE)
     }
 
     return runCatching(block).throwIf {

--- a/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Binding.kt
+++ b/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Binding.kt
@@ -27,7 +27,7 @@ import kotlin.contracts.contract
  */
 public inline fun <V, E> binding(crossinline block: BindingScope<E>.() -> V): Result<V, E> {
     contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        callsInPlace(block, InvocationKind.AT_MOST_ONCE)
     }
 
     return with(BindingScopeImpl<E>()) {

--- a/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Factory.kt
+++ b/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Factory.kt
@@ -10,7 +10,7 @@ import kotlin.contracts.contract
  */
 public inline fun <V> runCatching(block: () -> V): Result<V, Throwable> {
     contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        callsInPlace(block, InvocationKind.AT_MOST_ONCE)
     }
 
     return try {
@@ -27,7 +27,7 @@ public inline fun <V> runCatching(block: () -> V): Result<V, Throwable> {
  */
 public inline infix fun <T, V> T.runCatching(block: T.() -> V): Result<V, Throwable> {
     contract {
-        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+        callsInPlace(block, InvocationKind.AT_MOST_ONCE)
     }
 
     return try {


### PR DESCRIPTION
The `runCatching` function was initially set to `InvocationKind.EXACTLY_ONCE`, which could lead to indeterminate behavior. Therefore, it has been changed to `InvocationKind.AT_MOST_ONCE`.

The problem occurs in the following case:

```kotlin
@Test
fun indeterminate() {
    val value: Int
    com.github.michaelbull.result.runCatching {
        throwableFunction()
        value = 1
    }

    assertEquals(
        expected = 0,
        actual = value,
    )
}
```

With `InvocationKind.EXACTLY_ONCE`, it is assumed that `value = 1` is executed. However, in practice, this may not happen, resulting in an indeterminate value (0).
