### PR TITLE
Fix an issue with zipOrAccumulate with two procedures.

### DIFF
--- a/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Zip.kt
+++ b/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Zip.kt
@@ -144,8 +144,8 @@ public inline fun <T1, T2, E, V> zipOrAccumulate(
     val result2 = producer2()
 
     val results = listOf(
-        producer1(),
-        producer2(),
+        result1,
+        result2,
     )
 
     return if (results.allOk()) {

--- a/kotlin-result/src/commonTest/kotlin/com/github/michaelbull/result/ZipTest.kt
+++ b/kotlin-result/src/commonTest/kotlin/com/github/michaelbull/result/ZipTest.kt
@@ -187,6 +187,52 @@ class ZipTest {
     class ZipOrAccumulate {
 
         @Test
+        fun returnsTransformedValueIfAllOfTwoOk() {
+            val result = zipOrAccumulate(
+                { Ok(10) },
+                { Ok(20) },
+                Int::plus,
+            )
+
+            assertEquals(
+                expected = Ok(30),
+                actual = result,
+            )
+        }
+
+        @Test
+        fun returnsOneErrIfOneOfTwoErr() {
+            val result = zipOrAccumulate(
+                { Ok(10) },
+                { produce(20, "hello") },
+                Int::plus,
+            )
+
+            val expectedErrors = listOf("hello")
+
+            assertEquals(
+                expected = Err(expectedErrors),
+                actual = result,
+            )
+        }
+
+        @Test
+        fun returnsErrsIfAllOfTwoErr() {
+            val result = zipOrAccumulate(
+                { produce(10, "foo") },
+                { produce(20, "bar") },
+                Int::plus,
+            )
+
+            val expectedErrors = listOf("foo", "bar")
+
+            assertEquals(
+                expected = Err(expectedErrors),
+                actual = result,
+            )
+        }
+
+        @Test
         fun returnsTransformedValueIfAllOk() {
             val result = zipOrAccumulate(
                 { Ok(10) },


### PR DESCRIPTION
PR for #111 .

I modified zipOrAccumulate with two procedures.
Previously each procedure was executed twice, but now it is executed only once.