### PR TITLE
Use Zulu instead of Temurin.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@9704b39bf258b59bc04b50fa2dd55e9ed76b47a8 # v4.1.0
         with:
-          distribution: temurin
+          distribution: zulu
           java-version: 8
 
       - name: Setup Gradle


### PR DESCRIPTION
Switch the Java distribution in CI from Temurin to Zulu.

The reason is that the current macos-latest runs on macOS 14 with arm64 architecture,
but Temurin doesn’t offer an arm64 build of Java 8.
https://github.com/actions/setup-java/issues/625

I became aware of this issue when I saw #112.
I hope this PR gets merged soon.