### PR TITLE
feat(parZip): add `parZip` functions for combining results of 2 to 5 computations in parallel

### DIFF
--- a/kotlin-result-coroutines/src/commonMain/kotlin/com/github/michaelbull/result/coroutines/ParZip.kt
+++ b/kotlin-result-coroutines/src/commonMain/kotlin/com/github/michaelbull/result/coroutines/ParZip.kt
@@ -5,215 +5,113 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrThrow
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
-import kotlin.coroutines.ContinuationInterceptor
-import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.jvm.JvmField
 import kotlin.jvm.Transient
 
 private typealias Producer<T, E> = suspend CoroutineScope.() -> Result<T, E>
 
-@PublishedApi
-internal class ParZipException(
+private class ParZipException(
     @JvmField @Transient val error: Any?
 ) : RuntimeException("parZip failed with error: $error")
 
-@PublishedApi
-internal inline val <V, E> Result<V, E>.valueOrThrowParZipException: V
-    get() = getOrThrow(::ParZipException)
-
-
-@Suppress("UNCHECKED_CAST")
-@PublishedApi
-internal inline fun <E> ParZipException.toErr(): Result<Nothing, E> = Err(error as E)
-
-
-/**
- * Runs [producer1] and [producer2] in parallel on [context], combining their successful results with [transform].
- * If either computation fails with an [Err], the other is cancelled, and the error is returned as [Err].
- *
- * Coroutine context is inherited from a [CoroutineScope], additional context elements can be specified with [context] argument.
- * If the combined context does not have any dispatcher nor any other [ContinuationInterceptor], then [Dispatchers.Default] is used.
- * **WARNING** If the combined context has a single threaded [ContinuationInterceptor],
- * this function will not run [producer1], [producer2] in parallel.
- */
-public suspend inline fun <T1, T2, E, V> parZip(
-    context: CoroutineContext = EmptyCoroutineContext,
-    crossinline producer1: Producer<T1, E>,
-    crossinline producer2: Producer<T2, E>,
-    crossinline transform: suspend CoroutineScope.(value1: T1, value2: T2) -> V,
+private suspend inline fun <T, E, V> parZipInternal(
+    producers: List<Producer<T, E>>,
+    crossinline transform: suspend CoroutineScope.(values: List<T>) -> V,
 ): Result<V, E> {
     contract {
-        callsInPlace(producer1, InvocationKind.AT_MOST_ONCE)
-        callsInPlace(producer2, InvocationKind.AT_MOST_ONCE)
         callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
     }
     return try {
         coroutineScope {
-            val d1 = async(context) { producer1().valueOrThrowParZipException }
-            val d2 = async(context) { producer2().valueOrThrowParZipException }
-            val values = awaitAll(d1, d2)
-            Ok(
-                @Suppress("UNCHECKED_CAST")
-                transform(values[0] as T1, values[1] as T2)
-            )
+            val values = producers
+                .map { producer -> async { producer().getOrThrow(::ParZipException) } }
+                .awaitAll()
+            Ok(transform(values))
         }
     } catch (e: ParZipException) {
-        e.toErr()
+        @Suppress("UNCHECKED_CAST")
+        Err(e.error as E)
     }
 }
 
 /**
- * Runs [producer1] and [producer2] in parallel on [Dispatchers.Default], combining their successful results with [transform].
+ * Runs [producer1] and [producer2] in parallel, combining their successful results with [transform].
  * If either computation fails with an [Err], the other is cancelled, and the error is returned as [Err].
  */
-public suspend inline fun <T1, T2, E, V> parZip(
-    crossinline producer1: Producer<T1, E>,
-    crossinline producer2: Producer<T2, E>,
-    crossinline transform: suspend CoroutineScope.(value1: T1, value2: T2) -> V,
-): Result<V, E> = parZip(Dispatchers.Default, producer1, producer2, transform)
-
-
-/**
- * Runs [producer1], [producer2], and [producer3] in parallel on [context], combining their successful results with [transform].
- * If any computation fails with an [Err], the others are cancelled, and the error is returned as [Err].
- *
- * Coroutine context is inherited from a [CoroutineScope], additional context elements can be specified with the [context] argument.
- * If the combined context does not have any dispatcher nor any other [ContinuationInterceptor], then [Dispatchers.Default] is used.
- * **WARNING** If the combined context has a single-threaded [ContinuationInterceptor],
- * this function will not run [producer1], [producer2], and [producer3] in parallel.
- */
-public suspend inline fun <T1, T2, T3, E, V> parZip(
-    context: CoroutineContext = EmptyCoroutineContext,
-    crossinline producer1: Producer<T1, E>,
-    crossinline producer2: Producer<T2, E>,
-    crossinline producer3: Producer<T3, E>,
-    crossinline transform: suspend CoroutineScope.(T1, T2, T3) -> V,
-): Result<V, E> {
-    contract {
-        callsInPlace(producer1, InvocationKind.AT_MOST_ONCE)
-        callsInPlace(producer2, InvocationKind.AT_MOST_ONCE)
-        callsInPlace(producer3, InvocationKind.AT_MOST_ONCE)
-        callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
+public suspend fun <T1, T2, E, V> parZip(
+    producer1: Producer<T1, E>,
+    producer2: Producer<T2, E>,
+    transform: suspend CoroutineScope.(T1, T2) -> V,
+): Result<V, E> =
+    parZipInternal(listOf(producer1, producer2)) {
+        @Suppress("UNCHECKED_CAST")
+        transform(it[0] as T1, it[1] as T2)
     }
-    return try {
-        coroutineScope {
-            val d1 = async(context) { producer1().valueOrThrowParZipException }
-            val d2 = async(context) { producer2().valueOrThrowParZipException }
-            val d3 = async(context) { producer3().valueOrThrowParZipException }
-            val values = awaitAll(d1, d2, d3)
-            Ok(
-                @Suppress("UNCHECKED_CAST")
-                transform(
-                    values[0] as T1,
-                    values[1] as T2,
-                    values[2] as T3
-                )
-            )
-        }
-    } catch (e: ParZipException) {
-        e.toErr()
-    }
-}
 
 /**
- * Runs [producer1], [producer2], [producer3], and [producer4] in parallel on [context], combining their successful results with [transform].
+ * Runs [producer1], [producer2], and [producer3] in parallel, combining their successful results with [transform].
  * If any computation fails with an [Err], the others are cancelled, and the error is returned as [Err].
- *
- * Coroutine context is inherited from a [CoroutineScope], additional context elements can be specified with the [context] argument.
- * If the combined context does not have any dispatcher nor any other [ContinuationInterceptor], then [Dispatchers.Default] is used.
- * **WARNING** If the combined context has a single-threaded [ContinuationInterceptor],
- * this function will not run [producer1], [producer2], [producer3], and [producer4] in parallel.
  */
-public suspend inline fun <T1, T2, T3, T4, E, V> parZip(
-    context: CoroutineContext = EmptyCoroutineContext,
-    crossinline producer1: Producer<T1, E>,
-    crossinline producer2: Producer<T2, E>,
-    crossinline producer3: Producer<T3, E>,
-    crossinline producer4: Producer<T4, E>,
-    crossinline transform: suspend CoroutineScope.(T1, T2, T3, T4) -> V,
-): Result<V, E> {
-    contract {
-        callsInPlace(producer1, InvocationKind.AT_MOST_ONCE)
-        callsInPlace(producer2, InvocationKind.AT_MOST_ONCE)
-        callsInPlace(producer3, InvocationKind.AT_MOST_ONCE)
-        callsInPlace(producer4, InvocationKind.AT_MOST_ONCE)
-        callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
+public suspend fun <T1, T2, T3, E, V> parZip(
+    producer1: Producer<T1, E>,
+    producer2: Producer<T2, E>,
+    producer3: Producer<T3, E>,
+    transform: suspend CoroutineScope.(T1, T2, T3) -> V,
+): Result<V, E> =
+    parZipInternal(listOf(producer1, producer2, producer3)) {
+        @Suppress("UNCHECKED_CAST")
+        transform(
+            it[0] as T1,
+            it[1] as T2,
+            it[2] as T3
+        )
     }
-    return try {
-        coroutineScope {
-            val d1 = async(context) { producer1().valueOrThrowParZipException }
-            val d2 = async(context) { producer2().valueOrThrowParZipException }
-            val d3 = async(context) { producer3().valueOrThrowParZipException }
-            val d4 = async(context) { producer4().valueOrThrowParZipException }
-            val values = awaitAll(d1, d2, d3, d4)
-            Ok(
-                @Suppress("UNCHECKED_CAST")
-                transform(
-                    values[0] as T1,
-                    values[1] as T2,
-                    values[2] as T3,
-                    values[3] as T4
-                )
-            )
-        }
-    } catch (e: ParZipException) {
-        e.toErr()
-    }
-}
 
 /**
- * Runs [producer1], [producer2], [producer3], [producer4], and [producer5] in parallel on [context], combining their successful results with [transform].
+ * Runs [producer1], [producer2], [producer3], and [producer4] in parallel, combining their successful results with [transform].
  * If any computation fails with an [Err], the others are cancelled, and the error is returned as [Err].
- *
- * Coroutine context is inherited from a [CoroutineScope], additional context elements can be specified with the [context] argument.
- * If the combined context does not have any dispatcher nor any other [ContinuationInterceptor], then [Dispatchers.Default] is used.
- * **WARNING** If the combined context has a single-threaded [ContinuationInterceptor],
- * this function will not run [producer1], [producer2], [producer3], [producer4], and [producer5] in parallel.
  */
-public suspend inline fun <T1, T2, T3, T4, T5, E, V> parZip(
-    context: CoroutineContext = EmptyCoroutineContext,
-    crossinline producer1: Producer<T1, E>,
-    crossinline producer2: Producer<T2, E>,
-    crossinline producer3: Producer<T3, E>,
-    crossinline producer4: Producer<T4, E>,
-    crossinline producer5: Producer<T5, E>,
-    crossinline transform: suspend CoroutineScope.(T1, T2, T3, T4, T5) -> V,
-): Result<V, E> {
-    contract {
-        callsInPlace(producer1, InvocationKind.AT_MOST_ONCE)
-        callsInPlace(producer2, InvocationKind.AT_MOST_ONCE)
-        callsInPlace(producer3, InvocationKind.AT_MOST_ONCE)
-        callsInPlace(producer4, InvocationKind.AT_MOST_ONCE)
-        callsInPlace(producer5, InvocationKind.AT_MOST_ONCE)
-        callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
+public suspend fun <T1, T2, T3, T4, E, V> parZip(
+    producer1: Producer<T1, E>,
+    producer2: Producer<T2, E>,
+    producer3: Producer<T3, E>,
+    producer4: Producer<T4, E>,
+    transform: suspend CoroutineScope.(T1, T2, T3, T4) -> V,
+): Result<V, E> =
+    parZipInternal(listOf(producer1, producer2, producer3, producer4)) {
+        @Suppress("UNCHECKED_CAST")
+        transform(
+            it[0] as T1,
+            it[1] as T2,
+            it[2] as T3,
+            it[3] as T4
+        )
     }
-    return try {
-        coroutineScope {
-            val d1 = async(context) { producer1().valueOrThrowParZipException }
-            val d2 = async(context) { producer2().valueOrThrowParZipException }
-            val d3 = async(context) { producer3().valueOrThrowParZipException }
-            val d4 = async(context) { producer4().valueOrThrowParZipException }
-            val d5 = async(context) { producer5().valueOrThrowParZipException }
-            val values = awaitAll(d1, d2, d3, d4, d5)
-            Ok(
-                @Suppress("UNCHECKED_CAST")
-                transform(
-                    values[0] as T1,
-                    values[1] as T2,
-                    values[2] as T3,
-                    values[3] as T4,
-                    values[4] as T5
-                )
-            )
-        }
-    } catch (e: ParZipException) {
-        e.toErr()
+
+/**
+ * Runs [producer1], [producer2], [producer3], [producer4], and [producer5] in parallel, combining their successful results with [transform].
+ * If any computation fails with an [Err], the others are cancelled, and the error is returned as [Err].
+ */
+public suspend fun <T1, T2, T3, T4, T5, E, V> parZip(
+    producer1: Producer<T1, E>,
+    producer2: Producer<T2, E>,
+    producer3: Producer<T3, E>,
+    producer4: Producer<T4, E>,
+    producer5: Producer<T5, E>,
+    transform: suspend CoroutineScope.(T1, T2, T3, T4, T5) -> V,
+): Result<V, E> =
+    parZipInternal(listOf(producer1, producer2, producer3, producer4, producer5)) {
+        @Suppress("UNCHECKED_CAST")
+        transform(
+            it[0] as T1,
+            it[1] as T2,
+            it[2] as T3,
+            it[3] as T4,
+            it[4] as T5
+        )
     }
-}

--- a/kotlin-result-coroutines/src/commonMain/kotlin/com/github/michaelbull/result/coroutines/ParZip.kt
+++ b/kotlin-result-coroutines/src/commonMain/kotlin/com/github/michaelbull/result/coroutines/ParZip.kt
@@ -1,0 +1,219 @@
+package com.github.michaelbull.result.coroutines
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.getOrThrow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.jvm.JvmField
+import kotlin.jvm.Transient
+
+private typealias Producer<T, E> = suspend CoroutineScope.() -> Result<T, E>
+
+@PublishedApi
+internal class ParZipException(
+    @JvmField @Transient val error: Any?
+) : RuntimeException("parZip failed with error: $error")
+
+@PublishedApi
+internal inline val <V, E> Result<V, E>.valueOrThrowParZipException: V
+    get() = getOrThrow(::ParZipException)
+
+
+@Suppress("UNCHECKED_CAST")
+@PublishedApi
+internal inline fun <E> ParZipException.toErr(): Result<Nothing, E> = Err(error as E)
+
+
+/**
+ * Runs [producer1] and [producer2] in parallel on [context], combining their successful results with [transform].
+ * If either computation fails with an [Err], the other is cancelled, and the error is returned as [Err].
+ *
+ * Coroutine context is inherited from a [CoroutineScope], additional context elements can be specified with [context] argument.
+ * If the combined context does not have any dispatcher nor any other [ContinuationInterceptor], then [Dispatchers.Default] is used.
+ * **WARNING** If the combined context has a single threaded [ContinuationInterceptor],
+ * this function will not run [producer1], [producer2] in parallel.
+ */
+public suspend inline fun <T1, T2, E, V> parZip(
+    context: CoroutineContext = EmptyCoroutineContext,
+    crossinline producer1: Producer<T1, E>,
+    crossinline producer2: Producer<T2, E>,
+    crossinline transform: suspend CoroutineScope.(value1: T1, value2: T2) -> V,
+): Result<V, E> {
+    contract {
+        callsInPlace(producer1, InvocationKind.AT_MOST_ONCE)
+        callsInPlace(producer2, InvocationKind.AT_MOST_ONCE)
+        callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
+    }
+    return try {
+        coroutineScope {
+            val d1 = async(context) { producer1().valueOrThrowParZipException }
+            val d2 = async(context) { producer2().valueOrThrowParZipException }
+            val values = awaitAll(d1, d2)
+            Ok(
+                @Suppress("UNCHECKED_CAST")
+                transform(values[0] as T1, values[1] as T2)
+            )
+        }
+    } catch (e: ParZipException) {
+        e.toErr()
+    }
+}
+
+/**
+ * Runs [producer1] and [producer2] in parallel on [Dispatchers.Default], combining their successful results with [transform].
+ * If either computation fails with an [Err], the other is cancelled, and the error is returned as [Err].
+ */
+public suspend inline fun <T1, T2, E, V> parZip(
+    crossinline producer1: Producer<T1, E>,
+    crossinline producer2: Producer<T2, E>,
+    crossinline transform: suspend CoroutineScope.(value1: T1, value2: T2) -> V,
+): Result<V, E> = parZip(Dispatchers.Default, producer1, producer2, transform)
+
+
+/**
+ * Runs [producer1], [producer2], and [producer3] in parallel on [context], combining their successful results with [transform].
+ * If any computation fails with an [Err], the others are cancelled, and the error is returned as [Err].
+ *
+ * Coroutine context is inherited from a [CoroutineScope], additional context elements can be specified with the [context] argument.
+ * If the combined context does not have any dispatcher nor any other [ContinuationInterceptor], then [Dispatchers.Default] is used.
+ * **WARNING** If the combined context has a single-threaded [ContinuationInterceptor],
+ * this function will not run [producer1], [producer2], and [producer3] in parallel.
+ */
+public suspend inline fun <T1, T2, T3, E, V> parZip(
+    context: CoroutineContext = EmptyCoroutineContext,
+    crossinline producer1: Producer<T1, E>,
+    crossinline producer2: Producer<T2, E>,
+    crossinline producer3: Producer<T3, E>,
+    crossinline transform: suspend CoroutineScope.(T1, T2, T3) -> V,
+): Result<V, E> {
+    contract {
+        callsInPlace(producer1, InvocationKind.AT_MOST_ONCE)
+        callsInPlace(producer2, InvocationKind.AT_MOST_ONCE)
+        callsInPlace(producer3, InvocationKind.AT_MOST_ONCE)
+        callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
+    }
+    return try {
+        coroutineScope {
+            val d1 = async(context) { producer1().valueOrThrowParZipException }
+            val d2 = async(context) { producer2().valueOrThrowParZipException }
+            val d3 = async(context) { producer3().valueOrThrowParZipException }
+            val values = awaitAll(d1, d2, d3)
+            Ok(
+                @Suppress("UNCHECKED_CAST")
+                transform(
+                    values[0] as T1,
+                    values[1] as T2,
+                    values[2] as T3
+                )
+            )
+        }
+    } catch (e: ParZipException) {
+        e.toErr()
+    }
+}
+
+/**
+ * Runs [producer1], [producer2], [producer3], and [producer4] in parallel on [context], combining their successful results with [transform].
+ * If any computation fails with an [Err], the others are cancelled, and the error is returned as [Err].
+ *
+ * Coroutine context is inherited from a [CoroutineScope], additional context elements can be specified with the [context] argument.
+ * If the combined context does not have any dispatcher nor any other [ContinuationInterceptor], then [Dispatchers.Default] is used.
+ * **WARNING** If the combined context has a single-threaded [ContinuationInterceptor],
+ * this function will not run [producer1], [producer2], [producer3], and [producer4] in parallel.
+ */
+public suspend inline fun <T1, T2, T3, T4, E, V> parZip(
+    context: CoroutineContext = EmptyCoroutineContext,
+    crossinline producer1: Producer<T1, E>,
+    crossinline producer2: Producer<T2, E>,
+    crossinline producer3: Producer<T3, E>,
+    crossinline producer4: Producer<T4, E>,
+    crossinline transform: suspend CoroutineScope.(T1, T2, T3, T4) -> V,
+): Result<V, E> {
+    contract {
+        callsInPlace(producer1, InvocationKind.AT_MOST_ONCE)
+        callsInPlace(producer2, InvocationKind.AT_MOST_ONCE)
+        callsInPlace(producer3, InvocationKind.AT_MOST_ONCE)
+        callsInPlace(producer4, InvocationKind.AT_MOST_ONCE)
+        callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
+    }
+    return try {
+        coroutineScope {
+            val d1 = async(context) { producer1().valueOrThrowParZipException }
+            val d2 = async(context) { producer2().valueOrThrowParZipException }
+            val d3 = async(context) { producer3().valueOrThrowParZipException }
+            val d4 = async(context) { producer4().valueOrThrowParZipException }
+            val values = awaitAll(d1, d2, d3, d4)
+            Ok(
+                @Suppress("UNCHECKED_CAST")
+                transform(
+                    values[0] as T1,
+                    values[1] as T2,
+                    values[2] as T3,
+                    values[3] as T4
+                )
+            )
+        }
+    } catch (e: ParZipException) {
+        e.toErr()
+    }
+}
+
+/**
+ * Runs [producer1], [producer2], [producer3], [producer4], and [producer5] in parallel on [context], combining their successful results with [transform].
+ * If any computation fails with an [Err], the others are cancelled, and the error is returned as [Err].
+ *
+ * Coroutine context is inherited from a [CoroutineScope], additional context elements can be specified with the [context] argument.
+ * If the combined context does not have any dispatcher nor any other [ContinuationInterceptor], then [Dispatchers.Default] is used.
+ * **WARNING** If the combined context has a single-threaded [ContinuationInterceptor],
+ * this function will not run [producer1], [producer2], [producer3], [producer4], and [producer5] in parallel.
+ */
+public suspend inline fun <T1, T2, T3, T4, T5, E, V> parZip(
+    context: CoroutineContext = EmptyCoroutineContext,
+    crossinline producer1: Producer<T1, E>,
+    crossinline producer2: Producer<T2, E>,
+    crossinline producer3: Producer<T3, E>,
+    crossinline producer4: Producer<T4, E>,
+    crossinline producer5: Producer<T5, E>,
+    crossinline transform: suspend CoroutineScope.(T1, T2, T3, T4, T5) -> V,
+): Result<V, E> {
+    contract {
+        callsInPlace(producer1, InvocationKind.AT_MOST_ONCE)
+        callsInPlace(producer2, InvocationKind.AT_MOST_ONCE)
+        callsInPlace(producer3, InvocationKind.AT_MOST_ONCE)
+        callsInPlace(producer4, InvocationKind.AT_MOST_ONCE)
+        callsInPlace(producer5, InvocationKind.AT_MOST_ONCE)
+        callsInPlace(transform, InvocationKind.AT_MOST_ONCE)
+    }
+    return try {
+        coroutineScope {
+            val d1 = async(context) { producer1().valueOrThrowParZipException }
+            val d2 = async(context) { producer2().valueOrThrowParZipException }
+            val d3 = async(context) { producer3().valueOrThrowParZipException }
+            val d4 = async(context) { producer4().valueOrThrowParZipException }
+            val d5 = async(context) { producer5().valueOrThrowParZipException }
+            val values = awaitAll(d1, d2, d3, d4, d5)
+            Ok(
+                @Suppress("UNCHECKED_CAST")
+                transform(
+                    values[0] as T1,
+                    values[1] as T2,
+                    values[2] as T3,
+                    values[3] as T4,
+                    values[4] as T5
+                )
+            )
+        }
+    } catch (e: ParZipException) {
+        e.toErr()
+    }
+}

--- a/kotlin-result-coroutines/src/commonTest/kotlin/com.github.michaelbull.result.coroutines/ParZipTest.kt
+++ b/kotlin-result-coroutines/src/commonTest/kotlin/com.github.michaelbull.result.coroutines/ParZipTest.kt
@@ -1,0 +1,45 @@
+package com.github.michaelbull.result.coroutines
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.and
+import com.github.michaelbull.result.zip
+import com.github.michaelbull.result.zipOrAccumulate
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ParZipTest {
+
+    data class ZipData3(val a: String, val b: Int, val c: Boolean)
+    data class ZipData4(val a: String, val b: Int, val c: Boolean, val d: Double)
+    data class ZipData5(val a: String, val b: Int, val c: Boolean, val d: Double, val e: Char)
+
+    class Zip {
+
+        @Test
+        fun returnsTransformedValueIfBothOk() = runTest {
+            val modifyGate = CompletableDeferred<Int>()
+
+            val result = parZip(
+                {
+                    modifyGate.await()
+                    delay(100)
+                    Ok(10)
+                },
+                {
+                    delay(100)
+                    Ok(20).also { modifyGate.complete(0) }
+                },
+                { v1, v2 -> v1 + v2 }
+            )
+
+            assertEquals(
+                expected = Ok(30),
+                actual = result,
+            )
+        }
+    }
+}

--- a/kotlin-result-coroutines/src/commonTest/kotlin/com.github.michaelbull.result.coroutines/ParZipTest.kt
+++ b/kotlin-result-coroutines/src/commonTest/kotlin/com.github.michaelbull.result.coroutines/ParZipTest.kt
@@ -2,14 +2,26 @@ package com.github.michaelbull.result.coroutines
 
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
-import com.github.michaelbull.result.and
-import com.github.michaelbull.result.zip
-import com.github.michaelbull.result.zipOrAccumulate
+import com.github.michaelbull.result.Result
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import kotlin.test.Test
 import kotlin.test.assertEquals
+
+private suspend inline fun simulateDelay() = delay(100)
+
+private suspend fun <V> produceErr(error: String): Result<V, String> {
+    simulateDelay()
+    return Err(error)
+}
+
+private suspend fun <V> produceOk(value: V): Result<V, String> {
+    simulateDelay()
+    return Ok(value)
+}
 
 class ParZipTest {
 
@@ -17,29 +29,183 @@ class ParZipTest {
     data class ZipData4(val a: String, val b: Int, val c: Boolean, val d: Double)
     data class ZipData5(val a: String, val b: Int, val c: Boolean, val d: Double, val e: Char)
 
-    class Zip {
+    @Test
+    fun parZip2ReturnsTransformedValueIfBothOk() = runTest {
+        val modifyGate = CompletableDeferred<Unit>()
 
-        @Test
-        fun returnsTransformedValueIfBothOk() = runTest {
-            val modifyGate = CompletableDeferred<Int>()
-
-            val result = parZip(
+        val result = withContext(Dispatchers.Default) {
+            parZip(
                 {
                     modifyGate.await()
-                    delay(100)
-                    Ok(10)
+                    produceOk(value = "producer1")
                 },
                 {
-                    delay(100)
-                    Ok(20).also { modifyGate.complete(0) }
+                    modifyGate.complete(Unit)
+                    produceOk(value = "producer2")
                 },
-                { v1, v2 -> v1 + v2 }
-            )
-
-            assertEquals(
-                expected = Ok(30),
-                actual = result,
+                { v1, v2 ->
+                    simulateDelay()
+                    v1 to v2
+                }
             )
         }
+
+        assertEquals(
+            expected = Ok("producer1" to "producer2"),
+            actual = result,
+        )
+    }
+
+    @Test
+    fun parZip2ReturnsErrIfOneOfTwoErr() = runTest {
+        val modifyGate = CompletableDeferred<Unit>()
+
+        val result = withContext(Dispatchers.Default) {
+            parZip(
+                {
+                    modifyGate.await()
+                    produceOk(value = "producer1")
+                },
+                {
+                    modifyGate.complete(Unit)
+                    produceErr<Int>(error = "failed")
+                },
+                { v1, v2 ->
+                    simulateDelay()
+                    v1 to v2
+                }
+            )
+        }
+
+        assertEquals(
+            expected = Err("failed"),
+            actual = result,
+        )
+    }
+
+    @Test
+    fun parZip3ReturnsTransformedValueIfAllOk() = runTest {
+        val result = withContext(Dispatchers.Default) {
+            parZip(
+                { produceOk(value = "producer1") },
+                { produceOk(value = 42) },
+                { produceOk(value = true) },
+                { v1, v2, v3 ->
+                    simulateDelay()
+                    ZipData3(v1, v2, v3)
+                }
+            )
+        }
+
+        assertEquals(
+            expected = Ok(ZipData3("producer1", 42, true)),
+            actual = result,
+        )
+    }
+
+    @Test
+    fun parZip3ReturnsErrIfOneOfThreeErr() = runTest {
+        val result = withContext(Dispatchers.Default) {
+            parZip(
+                { produceOk(value = "producer1") },
+                { produceErr<Int>(error = "failed") },
+                { produceOk(value = true) },
+                { v1, v2, v3 ->
+                    simulateDelay()
+                    ZipData3(v1, v2, v3)
+                }
+            )
+        }
+
+        assertEquals(
+            expected = Err("failed"),
+            actual = result,
+        )
+    }
+
+    @Test
+    fun parZip4ReturnsTransformedValueIfAllOk() = runTest {
+        val result = withContext(Dispatchers.Default) {
+            parZip(
+                { produceOk(value = "producer1") },
+                { produceOk(value = 42) },
+                { produceOk(value = true) },
+                { produceOk(value = 3.14) },
+                { v1, v2, v3, v4 ->
+                    simulateDelay()
+                    ZipData4(v1, v2, v3, v4)
+                }
+            )
+        }
+
+        assertEquals(
+            expected = Ok(ZipData4("producer1", 42, true, 3.14)),
+            actual = result,
+        )
+    }
+
+    @Test
+    fun parZip4ReturnsErrIfOneOfFourErr() = runTest {
+        val result = withContext(Dispatchers.Default) {
+            parZip(
+                { produceOk(value = "producer1") },
+                { produceErr<Int>(error = "failed") },
+                { produceOk(value = true) },
+                { produceOk(value = 3.14) },
+                { v1, v2, v3, v4 ->
+                    simulateDelay()
+                    ZipData4(v1, v2, v3, v4)
+                }
+            )
+        }
+
+        assertEquals(
+            expected = Err("failed"),
+            actual = result,
+        )
+    }
+
+    @Test
+    fun parZip5ReturnsTransformedValueIfAllOk() = runTest {
+        val result = withContext(Dispatchers.Default) {
+            parZip(
+                { produceOk(value = "producer1") },
+                { produceOk(value = 42) },
+                { produceOk(value = true) },
+                { produceOk(value = 3.14) },
+                { produceOk(value = 'X') },
+                { v1, v2, v3, v4, v5 ->
+                    simulateDelay()
+                    ZipData5(v1, v2, v3, v4, v5)
+                }
+            )
+        }
+
+        assertEquals(
+            expected = Ok(ZipData5("producer1", 42, true, 3.14, 'X')),
+            actual = result,
+        )
+    }
+
+    @Test
+    fun parZip5ReturnsErrIfOneOfFiveErr() = runTest {
+        val result = withContext(Dispatchers.Default) {
+            parZip(
+                { produceOk(value = "producer1") },
+                { produceErr<Int>(error = "failed") },
+                { produceOk(value = true) },
+                { produceOk(value = 3.14) },
+                { produceOk(value = 'X') },
+                { v1, v2, v3, v4, v5 ->
+                    simulateDelay()
+                    ZipData5(v1, v2, v3, v4, v5)
+                }
+            )
+        }
+
+        assertEquals(
+            expected = Err("failed"),
+            actual = result,
+        )
     }
 }


### PR DESCRIPTION
This pull request introduces a new `parZip` utility to the `kotlin-result-coroutines` library, which allows running multiple computations in parallel and combining their results. It also includes comprehensive test cases to validate the functionality of `parZip` for various scenarios.

- Inspired by [arrow-fx-coroutines parZip](https://arrow-kt.io/learn/coroutines/parallel/#integration-with-typed-errors).
 
  Regarding the name `parZip`, I chose it by following the naming convention of the `Arrow.kt` library. If you have a better suggestion, I will update this PR accordingly 🙏.

- Added `parZip` functions for combining results of 2 to 5 computations in parallel. If any computation fails, the others are cancelled, and the error is returned.

- Added `ParZipTest` class with test cases to verify the behavior of `parZip` for 2 to 5 computations.

## Example

```kotlin

data class Movie(val id: Int, val title: String)

suspend fun getFavoriteMovies(): Result<List<Movie>, String> {
    delay(100) // simulate network delay
    return Ok(
        listOf(
            Movie(1, "Inception"),
            Movie(2, "The Matrix")
        )
    )
}

suspend fun getPopularMovies(): Result<List<Movie>, String> {
    delay(100) // simulate network delay
    return Ok(
        listOf(
            Movie(3, "Avengers: Endgame"),
            Movie(4, "Titanic")
        )
    )
}

suspend fun getTopRatedMovies(): Result<List<Movie>, String> {
    delay(100) // simulate network delay
    return Ok(
        listOf(
            Movie(5, "The Shawshank Redemption"),
            Movie(6, "The Godfather")
        )
    )
}

// --------------------------------------------------------

data class HomePageMovies(
    val favoriteMovies: List<Movie>,
    val popularMovies: List<Movie>,
    val topRatedMovies: List<Movie>
)

suspend fun getHomePageMoviesParZip(): Result<HomePageMovies, String> =
    withContext(Dispatchers.IO) {
        parZip(
            { getFavoriteMovies() },
            { getPopularMovies() },
            { getTopRatedMovies() },
        ) { favoriteMovies, popularMovies, topRatedMovies ->
            HomePageMovies(
                favoriteMovies = favoriteMovies,
                popularMovies = popularMovies,
                topRatedMovies = topRatedMovies
            )
        }
    }
```

```kotlin
// Compare getHomePageMoviesParZip with getHomePageMoviesSequentially:
// The execution time of getHomePageMoviesParZip is significantly less than that of getHomePageMoviesSequentially.
// -> it will improve the app performance and user experience.

suspend fun getHomePageMoviesSequentially(): Result<HomePageMovies, String> =
    withContext(Dispatchers.IO) {
        coroutineBinding {
            HomePageMovies(
                favoriteMovies = getFavoriteMovies().bind(),
                popularMovies = getPopularMovies().bind(),
                topRatedMovies = getTopRatedMovies().bind(),
            )
        }
    }
```