### PR TITLE
Add UnsafeResultValueAccess annotation to Result class for safer value access

### DIFF
--- a/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -59,6 +59,7 @@ kotlin {
         all {
             languageSettings.apply {
                 optIn("kotlin.contracts.ExperimentalContracts")
+                optIn("com.github.michaelbull.result.UnsafeResultValueAccess")
             }
         }
 

--- a/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Result.kt
+++ b/kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Result.kt
@@ -51,10 +51,12 @@ public value class Result<out V, out E> internal constructor(
     private val inlineValue: Any?,
 ) {
 
+    @UnsafeResultValueAccess
     @Suppress("UNCHECKED_CAST")
     public val value: V
         get() = inlineValue as V
 
+    @UnsafeResultValueAccess
     @Suppress("UNCHECKED_CAST")
     public val error: E
         get() = (inlineValue as Failure<E>).error
@@ -102,3 +104,19 @@ private class Failure<out E>(
         return "Failure($error)"
     }
 }
+
+/**
+ * Marks access to [Result.value] or [Result.error] as potentially unsafe unless the [Result]
+ * is explicitly checked for [Result.isOk] or [Result.isErr] beforehand.
+ *
+ * Ensure that you verify the [Result] state using [Result.isOk] or [Result.isErr] before accessing its value.
+ * Alternatively, consider using the [Result.fold] function to safely handle the result.
+ */
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "Accessing Result.value or Result.error without checking the Result state may lead to unsafe behavior.",
+)
+@MustBeDocumented
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.PROPERTY)
+public annotation class UnsafeResultValueAccess


### PR DESCRIPTION
Issue #104 

This pull request introduces a new `@UnsafeResultValueAccess` annotation to enforce safer access patterns for `Result.value` and `Result.error` in the `kotlin-result` library. Additionally, it updates the Kotlin conventions to opt into this annotation. Below are the key changes:

### Enhancements to `Result` class safety:

* Added the `@UnsafeResultValueAccess` annotation to mark access to `Result.value` and `Result.error` as potentially unsafe unless the `Result` state is explicitly checked using `Result.isOk` or `Result.isErr`. This encourages safer usage patterns. (`kotlin-result/src/commonMain/kotlin/com/github/michaelbull/result/Result.kt`, [[1]](diffhunk://#diff-84a8bfe8d281dcc7d79384c9770c83586c852246035e81d93eb2f0cd7d14cc02R54-R59) [[2]](diffhunk://#diff-84a8bfe8d281dcc7d79384c9770c83586c852246035e81d93eb2f0cd7d14cc02R107-R122)

### Kotlin conventions update:

* Updated the Kotlin conventions in `kotlin-conventions.gradle.kts` to opt into the `@UnsafeResultValueAccess` annotation, ensuring that projects using this configuration can leverage the new safety mechanism. (`buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts`, [buildSrc/src/main/kotlin/kotlin-conventions.gradle.ktsR62](diffhunk://#diff-512f24ca000c4a4211f731f7eae50d295161039d8c8018e5a9ee61d3a8182f33R62))