### PR TITLE
Fix nested coroutines binding issue

### DIFF
--- a/kotlin-result-coroutines/src/commonMain/kotlin/com/github/michaelbull/result/coroutines/CoroutineBinding.kt
+++ b/kotlin-result-coroutines/src/commonMain/kotlin/com/github/michaelbull/result/coroutines/CoroutineBinding.kt
@@ -56,7 +56,7 @@ public suspend inline fun <V, E> coroutineBinding(crossinline block: suspend Cor
             }
         }
     } catch (ex: BindCancellationException) {
-        receiver.result!!
+        receiver.result ?: throw ex
     }
 }
 


### PR DESCRIPTION
Fix for #128 .

When running nested coroutine bindings in parallel, an exception in one will trigger a `BindCancellationException` in the other, essentially leaking the exception over. Then the exception handler code is crashing because `receiver.result` may not be ready. A diagram explaining the issue:
<img width="902" height="606" alt="465261096-e415fd4f-ae7f-42cc-a62b-813f2c393ccc" src="https://github.com/user-attachments/assets/e148c4ba-2850-4b61-b7ea-a57cf4492b77" />